### PR TITLE
Fix parsing bug

### DIFF
--- a/test/spec/Radicle/Tests.hs
+++ b/test/spec/Radicle/Tests.hs
@@ -111,6 +111,9 @@ test_parser =
         "++" ==> Atom (i "++")
         "what?crazy!" ==> Atom (i "what?crazy!")
 
+    , testCase "parses identifiers that have a primop as prefix" $ do
+        "evaluate" ==> Atom (i "evaluate")
+
     , testCase "parses function application" $ do
         "(++)" ==> (Atom (i "++") $$ [])
         "(++ \"merge\" \"d\")" ==> (Atom (i "++") $$ [String "merge", String "d"])


### PR DESCRIPTION
    Wherein atoms with prefixes that matched existing primops would be
    parsed as the primop.

    Also introduces 'eof' into the higher-level parsing functions so
    input won't get silently dropped.

    Fixes #8.