### PR TITLE
Add stack traces to error messages

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -186,6 +186,7 @@ language_extensions:
   - DeriveFunctor
   - DeriveGeneric
   - DeriveTraversable
+  - ExplicitNamespaces
   - FlexibleContexts
   - FlexibleInstances
   - FunctionalDependencies

--- a/exe/Repl/Main.hs
+++ b/exe/Repl/Main.hs
@@ -8,13 +8,14 @@ import           Radicle
 main :: IO ()
 main = do
     opts' <- execParser allOpts
-    cfgSrc <- readFile =<< case configFile opts' of
+    cfgFile <- case configFile opts' of
         Nothing  -> getConfig
         Just cfg -> pure cfg
+    cfgSrc <- readFile cfgFile
     hist <- case histFile opts' of
         Nothing -> getHistory
         Just h  -> pure h
-    repl (Just hist) cfgSrc replBindings
+    repl (Just hist) (toS cfgFile) cfgSrc replBindings
   where
     allOpts = info (opts <**> helper)
         ( fullDesc

--- a/package.yaml
+++ b/package.yaml
@@ -18,6 +18,7 @@ dependencies:
 - haskeline
 - megaparsec
 - mtl
+- pointed
 - prettyprinter
 - prettyprinter-ansi-terminal
 - recursion-schemes

--- a/src/Radicle.hs
+++ b/src/Radicle.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 -- | `radicle` - A LISP for blocktrees.
 --
 -- `radicle` is a *reflective* language, meaning evaluation can be modified,
@@ -19,10 +21,23 @@ module Radicle
     -- ** Datatypes
     --
     -- *** Value
-    , Value(..)
+    , ValueF(..)
+    , type Value
+    , pattern Atom
+    , pattern Keyword
+    , pattern String
+    , pattern Number
+    , pattern Boolean
+    , pattern List
+    , pattern Primop
+    , pattern Dict
+    , pattern Ref
+    , pattern Lambda
     , maybeJson
     -- *** LangError
     , LangError(..)
+    , LangErrorData(..)
+    , throwErrorHere
     , Ident(..)
     , Reference(..)
     , mkIdent

--- a/src/Radicle/Internal/Annotation.hs
+++ b/src/Radicle/Internal/Annotation.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+module Radicle.Internal.Annotation where
+
+import           Codec.Serialise (Serialise)
+import           Data.Copointed (Copointed(..))
+import           Data.Text (pack)
+import           Protolude
+import qualified Text.Megaparsec.Pos as Par
+
+newtype Annotated t f = Annotated (t (f (Annotated t f)))
+    deriving (Generic)
+
+-- Really should depend on Eq1 etc. but that is so much boilerplate.
+-- Instead we use some UndecidableInstances.
+deriving instance (Eq (t (f (Annotated t f)))) => Eq (Annotated t f)
+deriving instance (Ord (t (f (Annotated t f)))) => Ord (Annotated t f)
+deriving instance (Read (t (f (Annotated t f)))) => Read (Annotated t f)
+deriving instance (Show (t (f (Annotated t f)))) => Show (Annotated t f)
+deriving instance (Serialise (t (f (Annotated t f)))) => Serialise (Annotated t f)
+
+class Annotation t where
+    -- We use the call stack to create source location annotations for interpreter-created objects
+    toAnnotation :: HasCallStack => a -> t a
+
+instance Annotation Identity where
+    toAnnotation = Identity
+
+untag :: (Functor f, Copointed t) => Annotated t f -> Annotated Identity f
+untag (Annotated t) = Annotated . Identity $ untag <$> copoint t
+
+tagDefault :: (Functor f, Annotation t) => Annotated Identity f -> Annotated t f
+tagDefault (Annotated (Identity t)) = Annotated (toAnnotation (tagDefault <$> t))
+
+match :: (Copointed t) => Annotated t f -> f (Annotated t f)
+match (Annotated t) = copoint t
+
+annotate :: (HasCallStack, Annotation t) => f (Annotated t f) -> Annotated t f
+annotate = withFrozenCallStack (Annotated . toAnnotation)
+
+
+data SrcPos = SrcPos Par.SourcePos
+            -- | If not associated with a source position, record where
+            -- in the interpreter this node was created (if only to know
+            -- what we need to improve).
+            --
+            -- We use Text instead of CallStack because CallStack has no
+            -- Read instance, and it's not worth it to make a parser.
+            | InternalPos Text
+    deriving (Eq, Ord, Read, Show, Generic)
+
+thisPos :: HasCallStack => SrcPos
+thisPos = InternalPos (pack (prettyCallStack callStack))
+
+data WithPos a = WithPos SrcPos a
+    deriving (Read, Show, Generic, Functor, Foldable, Traversable)
+
+-- Ignore source locations when comparing.
+instance Eq a => Eq (WithPos a) where
+    WithPos _ x == WithPos _ y = x == y
+
+instance (Ord a) => Ord (WithPos a) where
+    compare (WithPos _ x) (WithPos _ y) = compare x y
+
+instance Copointed WithPos where
+    copoint (WithPos _ x) = x
+
+instance Annotation WithPos where
+    toAnnotation = WithPos thisPos
+

--- a/src/Radicle/Internal/Interpret.hs
+++ b/src/Radicle/Internal/Interpret.hs
@@ -5,6 +5,7 @@ import           Protolude
 import qualified Data.Map.Strict as Map
 import           Text.Megaparsec (eof, runParserT)
 
+import qualified Radicle.Internal.Annotation as Ann
 import           Radicle.Internal.Core
 import           Radicle.Internal.Parse
 
@@ -14,11 +15,11 @@ import           Radicle.Internal.Parse
 --
 -- >>> import Control.Monad.Identity
 -- >>> import Radicle.Internal.Primops
--- >>> runIdentity $ interpret "test" "((lambda (x) x) #t)" pureEnv
--- Right (Boolean True)
+-- >>> fmap Ann.untag . runIdentity $ interpret "test" "((lambda (x) x) #t)" pureEnv
+-- Right (Annotated (Identity (BooleanF True)))
 --
 -- >>> import Control.Monad.Identity
--- >>> runIdentity $ interpret "test" "(#t #f)" pureEnv
+-- >>> noStack . runIdentity $ interpret "test" "(#t #f)" pureEnv
 -- Left (TypeError "Trying to apply a non-function")
 interpret
     :: Monad m
@@ -30,7 +31,7 @@ interpret sourceName expr bnds = do
     let primopNames = Map.keys (getPrimops $ bindingsPrimops bnds)
         parsed = runReader (runParserT (spaceConsumer *> valueP <* eof) (toS sourceName) expr) primopNames
     case parsed of
-        Left e  -> pure . Left $ ParseError e
+        Left e  -> pure . Left $ LangError [Ann.thisPos] (ParseError e)
         Right v -> fst <$> runLang bnds (eval v)
 
 -- | Parse and evaluate a Text as multiple expressions.
@@ -41,8 +42,8 @@ interpret sourceName expr bnds = do
 -- Examples:
 --
 -- >>> import Radicle.Internal.Primops
--- >>> fmap fst <$> runLang pureEnv $ interpretMany "test" "(define id (lambda (x) x))\n(id #t)"
--- Right (Boolean True)
+-- >>> fmap (fmap Ann.untag . fst) <$> runLang pureEnv $ interpretMany "test" "(define id (lambda (x) x))\n(id #t)"
+-- Right (Annotated (Identity (BooleanF True)))
 interpretMany
     :: Monad m
     => Text  -- ^ Name of source file (for error reporting)
@@ -56,6 +57,6 @@ interpretMany sourceName src = do
           es <- mapM eval vs
           case lastMay es of
              Just e -> pure e
-             _ -> throwError
+             _ -> throwErrorHere
                 $ OtherError "InterpretMany should be called with at least one expression."
-        (e:_, _) -> throwError $ ParseError e
+        (e:_, _) -> throwErrorHere $ ParseError e

--- a/src/Radicle/Internal/Primops.hs
+++ b/src/Radicle/Internal/Primops.hs
@@ -35,52 +35,53 @@ purePrimops = Primops $ fromList $ first Ident <$>
     [ ( "lambda"
       , \case
           List atoms_ : b : bs -> do
-            atoms <- traverse isAtom atoms_ ?? TypeError "lambda: expecting a list of symbols"
+            atoms <- traverse isAtom atoms_ ?? toLangError (TypeError "lambda: expecting a list of symbols")
             e <- gets bindingsEnv
             pure (Lambda atoms (b :| bs) e)
-          xs -> throwError $ WrongNumberOfArgs "lambda" 2 (length xs) -- TODO: technically "at least 2"
+          xs -> throwErrorHere $ WrongNumberOfArgs "lambda" 2 (length xs) -- TODO: technically "at least 2"
       )
     , ( "base-eval"
       , evalArgs $ \case
           [expr, st] -> case (fromRad st :: Either Text (Bindings ())) of
-              Left e -> throwError $ OtherError e
+              Left e -> throwErrorHere $ OtherError e
               Right st' -> do
                 prims <- gets bindingsPrimops
                 withBindings (const $ fmap (const prims) st') $ do
                   val <- baseEval expr
                   st'' <- get
                   pure $ List [val, toRad st'']
-          xs -> throwError $ WrongNumberOfArgs "base-eval" 2 (length xs)
+          xs -> throwErrorHere $ WrongNumberOfArgs "base-eval" 2 (length xs)
       )
     , ( "pure-env"
       , \case
           [] -> pure $ toRad (pureEnv :: Bindings (Primops m))
-          xs -> throwError $ WrongNumberOfArgs "pure-env" 0 (length xs)
+          xs -> throwErrorHere $ WrongNumberOfArgs "pure-env" 0 (length xs)
       )
     , ("apply", evalArgs $ \case
           [fn, List args] -> eval . List $ fn:args
-          [_, _]          -> throwError $ TypeError "apply: expecting list as second arg"
-          xs -> throwError $ WrongNumberOfArgs "apply" 2 (length xs))
+          [_, _]          -> throwErrorHere $ TypeError "apply: expecting list as second arg"
+          xs -> throwErrorHere $ WrongNumberOfArgs "apply" 2 (length xs))
     , ( "read"
       , evalOneArg "read" $ \case
           String s -> readValue s
-          _ -> throwError $ TypeError "read: expects string"
+          _ -> throwErrorHere $ TypeError "read: expects string"
       )
     , ("get-current-env", \case
           [] -> toRad <$> get
-          xs -> throwError $ WrongNumberOfArgs "get-current-env" 0 (length xs))
+          xs -> throwErrorHere $ WrongNumberOfArgs "get-current-env" 0 (length xs))
     , ("list", evalArgs $ \args -> pure $ List args)
-    , ("dict", evalArgs $ (Dict . foldr (uncurry Map.insert) mempty <$>) . evenArgs "dict")
+    , ("dict", evalArgs $ (Dict . foldr (uncurry Map.insert) mempty <$>)
+                        . evenArgs "dict")
     , ("quote", \args -> case args of
           [v] -> pure v
-          xs  -> throwError $ WrongNumberOfArgs "quote" 1 (length xs))
+          xs  -> throwErrorHere $ WrongNumberOfArgs "quote" 1 (length xs))
     , ("define", \args -> case args of
           [Atom name, val] -> do
               val' <- baseEval val
               defineAtom name val'
               pure nil
-          [_, _]           -> throwError $ OtherError "define expects atom for first arg"
-          xs               -> throwError $ WrongNumberOfArgs "define" 2 (length xs))
+          [_, _]           -> throwErrorHere $ OtherError "define expects atom for first arg"
+          xs               -> throwErrorHere $ WrongNumberOfArgs "define" 2 (length xs))
     , ( "define-rec"
       , \case
           [Atom name, val] -> do
@@ -90,50 +91,51 @@ purePrimops = Primops $ fromList $ first Ident <$>
                     let v = Lambda is b (Env . Map.insert name v . fromEnv $ e)
                     defineAtom name v
                     pure nil
-                _ -> throwError $ OtherError "define-rec can only be used to define functions"
-          [_, _]           -> throwError $ OtherError "define-rec expects atom for first arg"
-          xs               -> throwError $ WrongNumberOfArgs "define-rec" 2 (length xs)
+                _ -> throwErrorHere $ OtherError "define-rec can only be used to define functions"
+          [_, _]           -> throwErrorHere $ OtherError "define-rec expects atom for first arg"
+          xs               -> throwErrorHere $ WrongNumberOfArgs "define-rec" 2 (length xs)
       )
     , ("do", evalArgs $ pure . lastDef nil)
     , ("catch", \args -> case args of
           [l, form, handler] -> do
               mlabel <- baseEval l
               case mlabel of
-                  Atom label -> baseEval form `catchError` \e -> do
-                     (thrownLabel, thrownValue) <- errorToValue e
+                  -- TODO reify stack
+                  Atom label -> baseEval form `catchError` \(LangError _stack e) -> do
+                     (thrownLabel, thrownValue) <- errorDataToValue e
                      if thrownLabel == label || label == Ident "any"
                          then handler $$ [thrownValue]
                          else baseEval form
-                  _ -> throwError $ TypeError "catch: first argument must be atom"
-          xs -> throwError $ WrongNumberOfArgs "catch" 3 (length xs))
+                  _ -> throwErrorHere $ TypeError "catch: first argument must be atom"
+          xs -> throwErrorHere $ WrongNumberOfArgs "catch" 3 (length xs))
     , ("throw", evalArgs $ \args -> case args of
-          [Atom label, exc] -> throwError $ ThrownError label exc
-          [_, _]            -> throwError $ TypeError "throw: first argument must be atom"
-          xs                -> throwError $ WrongNumberOfArgs "throw" 2 (length xs))
+          [Atom label, exc] -> throwErrorHere $ ThrownError label exc
+          [_, _]            -> throwErrorHere $ TypeError "throw: first argument must be atom"
+          xs                -> throwErrorHere $ WrongNumberOfArgs "throw" 2 (length xs))
     , ("eq?", evalArgs $ \args -> case args of
           [a, b] -> pure $ Boolean (a == b)
-          xs     -> throwError $ WrongNumberOfArgs "eq?" 2 (length xs))
+          xs     -> throwErrorHere $ WrongNumberOfArgs "eq?" 2 (length xs))
     , ("cons", evalArgs $ \args -> case args of
           [x, List xs] -> pure $ List (x:xs)
-          [_, _]       -> throwError $ TypeError "cons: second argument must be list"
-          xs           -> throwError $ WrongNumberOfArgs "cons" 2 (length xs))
+          [_, _]       -> throwErrorHere $ TypeError "cons: second argument must be list"
+          xs           -> throwErrorHere $ WrongNumberOfArgs "cons" 2 (length xs))
     , ("head", evalOneArg "head" $ \case
           List (x:_) -> pure x
-          List []    -> throwError $ OtherError "head: empty list"
-          _          -> throwError $ TypeError "head: expects list argument")
+          List []    -> throwErrorHere $ OtherError "head: empty list"
+          _          -> throwErrorHere $ TypeError "head: expects list argument")
     , ("tail", evalOneArg "tail" $ \case
           List (_:xs) -> pure $ List xs
-          List []     -> throwError $ OtherError "tail: empty list"
-          _           -> throwError $ TypeError "tail: expects list argument")
+          List []     -> throwErrorHere $ OtherError "tail: empty list"
+          _           -> throwErrorHere $ TypeError "tail: expects list argument")
     , ( "nth"
       , evalArgs $ \case
           [Number n, List xs] -> case floatingOrInteger n of
-            Left (_ :: Double) -> throwError $ OtherError "nth: first argument was not an integer"
+            Left (_ :: Double) -> throwErrorHere $ OtherError "nth: first argument was not an integer"
             Right i -> case xs `atMay` i of
                 Just x  -> pure x
-                Nothing -> throwError $ OtherError "nth: index out of bounds"
-          [_,_] -> throwError $ TypeError "nth: expects a integer and a list"
-          xs -> throwError $ WrongNumberOfArgs "nth" 2 (length xs)
+                Nothing -> throwErrorHere $ OtherError "nth: index out of bounds"
+          [_,_] -> throwErrorHere $ TypeError "nth: expects a integer and a list"
+          xs -> throwErrorHere $ WrongNumberOfArgs "nth" 2 (length xs)
       )
     , ("lookup", evalArgs $ \args -> case args of
           [a, Dict m] -> pure $ case Map.lookup a m of
@@ -141,20 +143,20 @@ purePrimops = Primops $ fromList $ first Ident <$>
               -- Probably an exception is better, but that seems cruel
               -- when you have no exception handling facilities.
               Nothing -> nil
-          [_, _]      -> throwError $ TypeError "lookup: second argument must be map"
-          xs -> throwError $ WrongNumberOfArgs "lookup" 2 (length xs))
+          [_, _]      -> throwErrorHere $ TypeError "lookup: second argument must be map"
+          xs -> throwErrorHere $ WrongNumberOfArgs "lookup" 2 (length xs))
     , ("string-append", evalArgs $ \args ->
           let fromStr (String s) = Just s
               fromStr _          = Nothing
               ss = fromStr <$> args
           in if all isJust ss
               then pure . String . mconcat $ catMaybes ss
-              else throwError $ TypeError "string-append: non-string argument")
+              else throwErrorHere $ TypeError "string-append: non-string argument")
     , ("insert", evalArgs $ \args -> case args of
           [k, v, Dict m] -> pure . Dict $ Map.insert k v m
-          [_, _, _]                -> throwError
+          [_, _, _]                -> throwErrorHere
                                     $ TypeError "insert: third argument must be a dict"
-          xs -> throwError $ WrongNumberOfArgs "insert" 3 (length xs))
+          xs -> throwErrorHere $ WrongNumberOfArgs "insert" 3 (length xs))
     -- The semantics of + and - in Scheme is a little messed up. (+ 3)
     -- evaluates to 3, and of (- 3) to -3. That's pretty intuitive.
     -- But while (+ 3 2 1) evaluates to 6, (- 3 2 1) evaluates to 0. So with -
@@ -168,26 +170,26 @@ purePrimops = Primops $ fromList $ first Ident <$>
     , numBinop (-) "-"
     , ("<", evalArgs $ \args -> case args of
           [Number x, Number y] -> pure $ Boolean (x < y)
-          [_, _]               -> throwError $ TypeError "<: expecting number"
-          xs                   -> throwError $ WrongNumberOfArgs "<" 2 (length xs))
+          [_, _]               -> throwErrorHere $ TypeError "<: expecting number"
+          xs                   -> throwErrorHere $ WrongNumberOfArgs "<" 2 (length xs))
     , (">", evalArgs $ \args -> case args of
           [Number x, Number y] -> pure $ Boolean (x > y)
-          [_, _]               -> throwError $ TypeError ">: expecting number"
-          xs                   -> throwError $ WrongNumberOfArgs ">" 2 (length xs))
+          [_, _]               -> throwErrorHere $ TypeError ">: expecting number"
+          xs                   -> throwErrorHere $ WrongNumberOfArgs ">" 2 (length xs))
     , ("foldl", evalArgs $ \args -> case args of
           [fn, init', List ls] -> foldlM (\b a -> callFn fn [b, a]) init' ls
-          [_, _, _]            -> throwError
+          [_, _, _]            -> throwErrorHere
                                 $ TypeError "foldl: third argument should be a list"
-          xs                   -> throwError $ WrongNumberOfArgs "foldl" 3 (length xs))
+          xs                   -> throwErrorHere $ WrongNumberOfArgs "foldl" 3 (length xs))
     , ("foldr", evalArgs $ \args -> case args of
           [fn, init', List ls] -> foldrM (\b a -> callFn fn [b, a]) init' ls
-          [_, _, _]            -> throwError
+          [_, _, _]            -> throwErrorHere
                                 $ TypeError "foldr: third argument should be a list"
-          xs                   -> throwError $ WrongNumberOfArgs "foldr" 3 (length xs))
+          xs                   -> throwErrorHere $ WrongNumberOfArgs "foldr" 3 (length xs))
     , ("map", evalArgs $ \args -> case args of
           [fn, List ls] -> List <$> traverse (callFn fn) (pure <$> ls)
-          [_, _]        -> throwError $ TypeError "map: second argument should be a list"
-          xs            -> throwError $ WrongNumberOfArgs "map" 3 (length xs))
+          [_, _]        -> throwErrorHere $ TypeError "map: second argument should be a list"
+          xs            -> throwErrorHere $ WrongNumberOfArgs "map" 3 (length xs))
     , ("keyword?", evalOneArg "keyword?" $ \case
           Keyword _ -> pure tt
           _         -> pure ff)
@@ -225,29 +227,29 @@ purePrimops = Primops $ fromList $ first Ident <$>
           _        -> pure ff)
     , ("member?", evalArgs $ \args -> case args of
           [x, List xs] -> pure . Boolean $ elem x xs
-          [_, _]       -> throwError
+          [_, _]       -> throwErrorHere
                         $ TypeError "member?: second argument must be list"
-          xs           -> throwError $ WrongNumberOfArgs "eq?" 2 (length xs))
+          xs           -> throwErrorHere $ WrongNumberOfArgs "eq?" 2 (length xs))
     , ("if", \args -> case args of
           [condition, t, f] -> do
             b <- baseEval condition
             -- I hate this as much as everyone that might ever read Haskell, but
             -- in Lisps a lot of things that one might object to are True...
             if b == ff then baseEval f else baseEval t
-          xs -> throwError $ WrongNumberOfArgs "if" 3 (length xs))
+          xs -> throwErrorHere $ WrongNumberOfArgs "if" 3 (length xs))
     , ( "cond", (cond =<<) . evenArgs "cond" )
     , ("ref", evalOneArg "ref" newRef)
     , ("read-ref", evalOneArg "read-ref" $ \case
           Ref ref -> readRef ref
-          _       -> throwError $ TypeError "read-ref: argument must be a ref")
+          _       -> throwErrorHere $ TypeError "read-ref: argument must be a ref")
     , ("write-ref", evalArgs $ \args -> case args of
           [Ref (Reference x), v] -> do
               st <- get
               put $ st { bindingsRefs = IntMap.insert x v $ bindingsRefs st }
               pure nil
-          [_, _]                 -> throwError
+          [_, _]                 -> throwErrorHere
                                   $ TypeError "write-ref: first argument must be a ref"
-          xs                     -> throwError
+          xs                     -> throwErrorHere
                                   $ WrongNumberOfArgs "write-ref" 2 (length xs))
     , ("show", evalOneArg "show" (pure . String . renderPrettyDef))
     , ( "seq"
@@ -255,25 +257,25 @@ purePrimops = Primops $ fromList $ first Ident <$>
           \case
             x@(List _) -> pure x
             Dict kvs -> pure $ List [List [k, v] | (k,v) <- Map.toList kvs ]
-            _ -> throwError $ TypeError "seq: can only create a list from a list or a dict"
+            _ -> throwErrorHere $ TypeError "seq: can only create a list from a list or a dict"
       )
     , ( "to-json"
       , evalOneArg "to-json" $ \v -> String . toS . Aeson.encode <$>
-          maybeJson v ?? OtherError "Could not serialise value to JSON"
+          maybeJson v ?? toLangError (OtherError "Could not serialise value to JSON")
       )
     , ( "default-ecc-curve",
         evalArgs $ \case
           [] -> pure $ toRad defaultCurve
-          xs -> throwError $ WrongNumberOfArgs "default-ecc-curve" 0 (length xs)
+          xs -> throwErrorHere $ WrongNumberOfArgs "default-ecc-curve" 0 (length xs)
       )
     , ( "verify-signature"
       , evalArgs $ \case
           [keyv, sigv, String msg] -> do
-            key <- hoistEither . first OtherError $ fromRad keyv
-            sig <- hoistEither . first OtherError $ fromRad sigv
+            key <- hoistEither . first (toLangError . OtherError) $ fromRad keyv
+            sig <- hoistEither . first (toLangError . OtherError) $ fromRad sigv
             pure . Boolean $ verifySignature key sig msg
-          [_, _, _] -> throwError $ OtherError "verify-signature: message must be a string"
-          xs -> throwError $ WrongNumberOfArgs "verify-signature" 3 (length xs)
+          [_, _, _] -> throwErrorHere $ OtherError "verify-signature: message must be a string"
+          xs -> throwErrorHere $ WrongNumberOfArgs "verify-signature" 3 (length xs)
       )
     ]
   where
@@ -289,7 +291,7 @@ purePrimops = Primops $ fromList $ first Ident <$>
     -- | Some forms/functions expect an even number or arguments.
     evenArgs name = \case
       [] -> pure []
-      [_] -> throwError . OtherError $ name <> ": expects an even number of arguments"
+      [_] -> throwErrorHere . OtherError $ name <> ": expects an even number of arguments"
       x:y:xs -> do
         ps <- evenArgs name xs
         pure ((x,y):ps)
@@ -304,11 +306,11 @@ purePrimops = Primops $ fromList $ first Ident <$>
         Number x:x':xs -> foldM go (Number x) (x':xs)
           where
             go (Number a) (Number b) = pure . Number $ fn a b
-            go _ _ = throwError . TypeError
+            go _ _ = throwErrorHere . TypeError
                    $ name <> ": expecting number"
-        [Number _] -> throwError
+        [Number _] -> throwErrorHere
                     $ OtherError $ name <> ": expects at least 2 arguments"
-        _ -> throwError $ TypeError $ name <> ": expecting number")
+        _ -> throwErrorHere $ TypeError $ name <> ": expecting number")
 
 -- * Helpers
 
@@ -320,7 +322,7 @@ evalArgs f args = traverse baseEval args >>= f
 evalOneArg :: Monad m => Text -> (Value -> Lang m Value) -> [Value] -> Lang m Value
 evalOneArg fname f = evalArgs $ \case
   [x] -> f x
-  xs -> throwError $ WrongNumberOfArgs fname 1 (length xs)
+  xs -> throwErrorHere $ WrongNumberOfArgs fname 1 (length xs)
 
 readValue
     :: (MonadError (LangError Value) m, MonadState (Bindings (Primops n)) m)
@@ -331,4 +333,4 @@ readValue s = do
     let p = parse "[read-primop]" s (Map.keys allPrims)
     case p of
       Right v -> pure v
-      Left e  -> throwError $ ThrownError (Ident "parse-error") (String e)
+      Left e  -> throwErrorHere $ ThrownError (Ident "parse-error") (String e)

--- a/test/spec/Radicle/Internal/TestCapabilities.hs
+++ b/test/spec/Radicle/Internal/TestCapabilities.hs
@@ -81,7 +81,7 @@ instance {-# OVERLAPPING #-} Stdin TestLang where
     getLineS = do
         ws <- lift get
         case worldStateStdin ws of
-            []   -> throwError Exit
+            []   -> throwErrorHere Exit
             h:hs -> lift (put $ ws { worldStateStdin = hs }) >> pure h
 
 instance {-# OVERLAPPING #-} Stdout TestLang where
@@ -93,7 +93,7 @@ instance {-# OVERLAPPING #-} ReadFile TestLang where
     fs <- lift $ gets worldStateFiles
     case Map.lookup fn fs of
       Just f  -> pure f
-      Nothing -> throwError . OtherError $ "File not found: " <> fn
+      Nothing -> throwErrorHere . OtherError $ "File not found: " <> fn
 
 instance MonadRandom (State WorldState) where
     getRandomBytes i = do


### PR DESCRIPTION
The most controversial change is that we change Value to open-recursion form, and then add an "Annotated" abstraction that allows us to put a functor between each level of the tree, which is where we will keep source locations.  Open recursion is a pretty convenient form to work with once you get used to it, and I think it will have other advantages in the future.

However, I did not go whole-hog refactoring the codebase to account for the extra polymorphism in open-recursion form, though it is possible.  Instead I just redefined Value = Annotated WithPos ValueF, so all Values just have some source location info.  Let's wait and see if there's another good use case for the open recursion to polymorphize everything.

We then create pattern synonyms for all of the constructors to maintain the old interface. These log as their source location the current Haskell call stack using HasCallStack -- so if we see one of these in our stack trace, at least we know where in our interpreter needs some extra error instrumentation.