### PR TITLE
Evaluating a dictionary evaluates the keys and the values.

### DIFF
--- a/src/Radicle/Internal/Core.hs
+++ b/src/Radicle/Internal/Core.hs
@@ -70,7 +70,7 @@ errorToValue e = case e of
     Exit -> makeVal ("exit", [])
   where
     makeA = quote . Atom
-    makeVal (t,v) = pure (Ident t, Dict $ Map.mapKeys (Atom . Ident) . GhcExts.fromList $ v)
+    makeVal (t,v) = pure (Ident t, Dict $ Map.mapKeys (Keyword . Ident) . GhcExts.fromList $ v)
 
 newtype Reference = Reference { getReference :: Int }
     deriving (Show, Read, Ord, Eq, Generic, Serialise)
@@ -280,10 +280,9 @@ baseEval val = case val of
                             2
                             (length xs)
     Dict mp -> do
-        let evalSnd (a,b) = (a ,) <$> baseEval b
-        Dict . Map.fromList <$> traverse evalSnd (Map.toList mp)
+        let evalBoth (a,b) = (,) <$> baseEval a <*> baseEval b
+        Dict . Map.fromList <$> traverse evalBoth (Map.toList mp)
     autoquote -> pure autoquote
-
 
 
 -- * Helpers

--- a/test/spec/Radicle/Tests.hs
+++ b/test/spec/Radicle/Tests.hs
@@ -40,6 +40,10 @@ test_eval =
         let prog2 = [s|(dict 3 1)|]
         prog2 `succeedsWith` Dict (fromList [(Number 3, Number 1)])
 
+    , testCase "Dicts evaluate both keys are arguments" $ do
+        "{(+ 1 1) (+ 1 1)}" `succeedsWith` Dict (fromList [(Number 2, Number 2)])
+        "{(+ 1 1) :a (+ 0 2) :b}" `succeedsWith` Dict (fromList [(Number 2, kw "a")])
+
     , testCase "'cons' conses an element" $ do
         let prog = [s|(cons #t (list #f))|]
         prog `succeedsWith` List [Boolean True, Boolean False]


### PR DESCRIPTION
This means that key-collisions may arise during evaluation. When this happens,
the order of the keys, prior to evaluation, is used to determine the winner of
the collision: largest key wins.

Fixes #110.