### PR TITLE
Prefix `client` and `server` executables

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You should probably run the client against radicle.xyz for fuller
 functionality.
 
 ```
-stack exec client -- --config rad/repl.rad --url radicle.xyz
+stack exec radicle-client -- --config rad/repl.rad --url radicle.xyz
 ```
 
 ## The language

--- a/package.yaml
+++ b/package.yaml
@@ -85,7 +85,7 @@ executables:
     - optparse-applicative
     ghc-options: -threaded -O3
 
-  server:
+  radicle-server:
     main: Server.hs
     source-dirs: exe/Server
     other-modules: API
@@ -105,7 +105,7 @@ executables:
     - wai-cors
     ghc-options: -main-is Server -O3 -threaded
 
-  client:
+  radicle-client:
     main: Client.hs
     source-dirs: exe/Server
     other-modules: API
@@ -123,7 +123,7 @@ executables:
         buildable: false
     ghc-options: -main-is Client -O3 -threaded
 
-  client-ghcjs:
+  radicle-client-ghcjs:
     main: GHCJS.hs
     source-dirs: exe/Server
     other-modules: API


### PR DESCRIPTION
To make the names of the executables non-ambiguous we rename them to `radicle-client` and `radicle-server`.