### PR TITLE
String literals are parsed/printed with escape sequences

### DIFF
--- a/src/Radicle/Internal/Parse.hs
+++ b/src/Radicle/Internal/Parse.hs
@@ -23,7 +23,7 @@ import           Text.Megaparsec
                  , (<?>)
                  )
 import qualified Text.Megaparsec as M
-import           Text.Megaparsec.Char (char, satisfy, space1)
+import           Text.Megaparsec.Char (char, satisfy, space1, string)
 import qualified Text.Megaparsec.Char.Lexer as L
 import qualified Text.Megaparsec.Error as Par
 
@@ -47,7 +47,6 @@ tag v = do
     pos <- getPosition -- N.B. in megaparsec 7 this is called getSourcePos
     pure $ Ann.Annotated (Ann.WithPos (Ann.SrcPos pos) v)
 
-
 symbol :: Text -> Parser Text
 symbol = L.symbol spaceConsumer
 
@@ -66,9 +65,12 @@ bracesP = inside "{" "}"
 sqBracketsP :: Parser a -> Parser a
 sqBracketsP = inside "[" "]"
 
+-- Parsing of string literals handles escape sequences just like Haskell does.
 stringLiteralP :: VParser
-stringLiteralP = lexeme $
-    tag =<< StringF . toS <$> (char '"' >> manyTill L.charLiteral (char '"'))
+stringLiteralP = lexeme $ tag =<< StringF . toS <$> escaptedString
+  where
+    escaptedString = catMaybes <$> (char '"' >> manyTill ch (char '"'))
+    ch = (Just <$> L.charLiteral) <|> (Nothing <$ string "\\&")
 
 boolLiteralP :: VParser
 boolLiteralP = lexeme $ tag =<< BooleanF <$> (char '#' >>

--- a/src/Radicle/Internal/Parse.hs
+++ b/src/Radicle/Internal/Parse.hs
@@ -67,7 +67,7 @@ sqBracketsP = inside "[" "]"
 
 -- Parsing of string literals handles escape sequences just like Haskell does.
 stringLiteralP :: VParser
-stringLiteralP = lexeme $ tag =<< StringF . toS <$> escaptedString
+stringLiteralP = lexeme $ tag =<< StringF . toS <$> escapedString
   where
     escapedString = catMaybes <$> (char '"' >> manyTill ch (char '"'))
     ch = (Just <$> L.charLiteral) <|> (Nothing <$ string "\\&")

--- a/src/Radicle/Internal/Parse.hs
+++ b/src/Radicle/Internal/Parse.hs
@@ -69,7 +69,7 @@ sqBracketsP = inside "[" "]"
 stringLiteralP :: VParser
 stringLiteralP = lexeme $ tag =<< StringF . toS <$> escaptedString
   where
-    escaptedString = catMaybes <$> (char '"' >> manyTill ch (char '"'))
+    escapedString = catMaybes <$> (char '"' >> manyTill ch (char '"'))
     ch = (Just <$> L.charLiteral) <|> (Nothing <$ string "\\&")
 
 boolLiteralP :: VParser

--- a/src/Radicle/Internal/Pretty.hs
+++ b/src/Radicle/Internal/Pretty.hs
@@ -50,7 +50,8 @@ instance (Copointed t, Ann.Annotation t) => Pretty (Ann.Annotated t ValueF) wher
                         , sep $ pretty <$> toList vals
                         ])
       where
-        escapeStr = T.replace "\"" "\\\"" . T.replace "\\" "\\\\"
+        -- We print string literals escaped just like Haskell does.
+        escapeStr = T.init . T.tail . show
 
 instance Pretty Ann.SrcPos where
     pretty (Ann.SrcPos pos)        = pretty (sourcePosPretty pos)

--- a/test/spec/Radicle/Tests.hs
+++ b/test/spec/Radicle/Tests.hs
@@ -554,6 +554,11 @@ test_pretty =
                                                                    , (kw "k2", Number 2)
                                                                    ]))
         r @?= "{:k1 1.0\n :k2 2.0}"
+    , testProperty "read . pprint == identity for strings" $ \(t :: Text) ->
+        let v = asValue (String t)
+            pp = renderPrettyDef v
+            v_ = parseTest pp
+        in v_ == Right v
     ]
   where
     apl cols = AvailablePerLine cols 1


### PR DESCRIPTION
And they work as defined in the Haskell report.

Fixes #126.