### PR TITLE
Update radicle files to reflect new eval

### DIFF
--- a/docs/source/guide/Chains.lrad
+++ b/docs/source/guide/Chains.lrad
@@ -1,5 +1,15 @@
 # Chains
 
+(N.B.: for this section, you should use the `radicle-client` executable rather
+than the `radicle` one. The simplest way to run it is to pass `radicle.xyz` as
+the `url` argument:
+
+```
+radicle-client --config rad/repl.rad --url radicle.xyz
+```
+
+In the future `radicle-client` and `radicle` will be folded into one.)
+
 By now you've seen some of `radicle`, but we haven't touched upon what makes it
 different from other languages.
 
@@ -10,47 +20,62 @@ particular machine. *Which* machine that is often matters to understanding how
 the program behaves; a program might after all read from a file, for example,
 and behave differently based on whether that file exists, and what it's
 contents are. But other machines may not have that file, or have one that
-differs in some way. 
+differs in some way.
 
 This aspect of program execution is often a source of headache for developers,
 as it leads to hard-to-reproduce or -predict behavior. But--and more
 importantly for our purposes--it also means we can't think of programs in the
 abstract
 
-In other words, we would like for programs to be *deterministic*. 
+In other words, we would like for programs to be *deterministic*.
 
 TODO: more.
 
-## Exploring chains
+## Chains
 
-Chains, then, are like environments.  You can enter an environment that
+### Remote chains
+
+The basic building blocks of interacting with remote chains are the `send!` and
+`receive!` operations. These send expressions to a remote chain, or receive new
+ones since a given index, respectively.
+
+These functions are, however, relatively low-level. Higher-level ones exist
+that do the grunt-work of only requesting data you don't already have, and of
+allowing interactive explorations of existing chains before submitting
+expressions. These are described in the next section.
+
+### Exploring chains
+
+Chains are a lot like shared environments.  You can enter an environment that
 corresponds to a chain and explore it:
 
 ```
-(def x 0) 
-x 			   ;; ==> 0
+(def x 0)
+x 			               ;; ==> 0
 (:enter-chain empty-chain) ;; ==> :ok
 (def x 1)
-x 			   ;; ==> 1
-:quit 			   ;; ==> :ok
-x 			   ;; ==> 0
+x 			   			   ;; ==> 1
+:quit 	       			   ;; ==> :ok
+x 						   ;; ==> 0
 ```
 
 As you can see, between entering a chain (with `:enter-chain`) and leaving it
 (with `:quit`), all inputs are evaluated in the context of that chain.
 
-(You may be wondering how `(:enter-chain empty-chain)` could possibly be valid, 
-as it contains a keyword apparently doing the job of a function application. 
+(You may be wondering how `(:enter-chain empty-chain)` could possibly be valid,
+as it contains a keyword apparently doing the job of a function application.
 The short answer is that we can define special macro-like operations, of which
 we will see more.)
 
 `:enter-chain` allows you to enter a local chain. More often, you'll want to
 explore and interact with chains that exist elsewhere--that are replicated in
 a distributed way, or exist in some centralized server. For that, you can use
-`:enter-remote-chain`. 
+`:enter-remote-chain`.
 
 `:enter-remote-chain` takes an argument just like `:enter-chain`, and indeed
 for the most part both behave identically. The main difference is that with
 `:enter-remote-chain`, you also have access to the special command `:send`,
 which sends all the inputs you have so far to the remote.
- 
+
+In order to receive new inputs and update the chain state accordingly, you
+can use the function `update-chain`.

--- a/docs/source/guide/Chains.lrad
+++ b/docs/source/guide/Chains.lrad
@@ -19,10 +19,12 @@ abstract
 
 In other words, we would like for programs to be *deterministic*. 
 
+TODO: more.
 
 ## Exploring chains
 
-You can enter an environment that corresponds to a chain:
+Chains, then, are like environments.  You can enter an environment that
+corresponds to a chain and explore it:
 
 ```
 (def x 0) 
@@ -41,3 +43,14 @@ As you can see, between entering a chain (with `:enter-chain`) and leaving it
 as it contains a keyword apparently doing the job of a function application. 
 The short answer is that we can define special macro-like operations, of which
 we will see more.)
+
+`:enter-chain` allows you to enter a local chain. More often, you'll want to
+explore and interact with chains that exist elsewhere--that are replicated in
+a distributed way, or exist in some centralized server. For that, you can use
+`:enter-remote-chain`. 
+
+`:enter-remote-chain` takes an argument just like `:enter-chain`, and indeed
+for the most part both behave identically. The main difference is that with
+`:enter-remote-chain`, you also have access to the special command `:send`,
+which sends all the inputs you have so far to the remote.
+ 

--- a/docs/source/guide/Chains.lrad
+++ b/docs/source/guide/Chains.lrad
@@ -18,3 +18,26 @@ importantly for our purposes--it also means we can't think of programs in the
 abstract
 
 In other words, we would like for programs to be *deterministic*. 
+
+
+## Exploring chains
+
+You can enter an environment that corresponds to a chain:
+
+```
+(def x 0) 
+x 			   ;; ==> 0
+(:enter-chain empty-chain) ;; ==> :ok
+(def x 1)
+x 			   ;; ==> 1
+:quit 			   ;; ==> :ok
+x 			   ;; ==> 0
+```
+
+As you can see, between entering a chain (with `:enter-chain`) and leaving it
+(with `:quit`), all inputs are evaluated in the context of that chain.
+
+(You may be wondering how `(:enter-chain empty-chain)` could possibly be valid, 
+as it contains a keyword apparently doing the job of a function application. 
+The short answer is that we can define special macro-like operations, of which
+we will see more.)

--- a/docs/source/guide/Chains.lrad
+++ b/docs/source/guide/Chains.lrad
@@ -51,12 +51,12 @@ corresponds to a chain and explore it:
 
 ```
 (def x 0)
-x 			               ;; ==> 0
+x                          ;; ==> 0
 (:enter-chain empty-chain) ;; ==> :ok
 (def x 1)
-x 			   			   ;; ==> 1
-:quit 	       			   ;; ==> :ok
-x 						   ;; ==> 0
+x                          ;; ==> 1
+:quit                      ;; ==> :ok
+x                          ;; ==> 0
 ```
 
 As you can see, between entering a chain (with `:enter-chain`) and leaving it

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -58,3 +58,4 @@ how to allow for future changes to the chain.
 
   GettingStarted.md
   Basics.lrad
+  Chains.lrad

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,7 @@ radicle
    guide/index.rst
    guide/GettingStarted.rst
    guide/Basics.lrad
+   guide/Chains.lrad
 
 
 

--- a/rad/chain.rad
+++ b/rad/chain.rad
@@ -5,6 +5,11 @@
 ;;     == base-eval')
 ;;   - A sequence of inputs.
 
+
+;; DELETEME
+(def eval-definer (fn [ev] (write-ref eval ev)))
+;; DELETEME
+
 (def empty-chain
   (dict :state (pure-env)
         :inputs (list)
@@ -12,7 +17,7 @@
 
 (def eval-in-chain
   (fn [expr chain]
-    (def x (eval-with-env expr (lookup :state chain)))
+    (def x (eval expr (lookup :state chain)))
     (dict :chain (dict :state (head (tail x))
                        :input (cons expr (lookup :logs chain))
                        :index (+ 1 (lookup :index chain)))
@@ -21,6 +26,11 @@
 (document 'eval-in-chain
           '(("expr" any) ("chain" chain))
           "Evaluates 'expr' in the 'chain' and returns a dict with the ':result' and the resulting ':chain'.")
+
+(do 
+  (def res (eval-in-chain (+ 3 2) empty-chain))
+  (def ~~> (fn [comp expected] (should-be "eval-in-chain" (lookup comp) expected)))
+  (~~> :result 5))
 
 (def update-chain-with
   (fn [chain remote-chain-id cb-expr cb-res]
@@ -39,7 +49,7 @@
           "Updates 'chain' according to activity on the remote chain with ID 'chain-id', by pulling down and evaluating new inputs. Accepts two callbacks: 'cb-expr' is applied to the incoming expressions, and 'cb-res' is applied to the resulting values. Usually one uses 'print!' for both of these. If 'chain' is not a past version of the remote chain then the behaviour is unspecified.")
 
 (def enter-chain
-  (fn [eval-definer chain]
+  (fn [chain]
     (def old-eval eval)
     (def ch (ref chain))
     (def ev
@@ -47,17 +57,17 @@
         (if (eq? e :quit)
             (do (print! "leaving chain")
                 (eval-definer old-eval))
-          (do (def x (eval-in-chain e (read-ref ch)))
+          (do (def x (eval e (read-ref ch)))
               (write-ref ch (view (@ :chain) x))
               (view (@ :result) x)))))
     (eval-definer ev)))
 
 (document 'enter-chain
-          '(("eval-definer" function) ("chain" chain))
+          '(("chain" chain))
           "Instantiates an 'eval' which evaluates expressions in 'chain'. The expression ':quit' will return to the previous eval. Uses the parameter 'eval-definer' for eval redefinition, this should be a function which can be used to redefine 'eval': it should set eval to it's input.")
 
 (def enter-remote-chain
-  (fn [eval-definer chain-id]
+  (fn [chain-id]
     (def old-eval eval)
     (def chain (update-chain-with empty-chain chain-id (fn [e] '()) (fn [e] '())))
     (print! (string-append "Synced with remote chain, at index: " (show (view (@ :index) chain))))
@@ -78,12 +88,8 @@
                   (view (@ :result) x)))))))
 
 (document 'enter-remote-chain
-          '(("eval-definer" function) ("chain-id" string))
+          '(("chain-id" string))
           "Syncs up to a remote chain, and allows experimentation inputs. There are two special inputs: ':quit' will leave the chain, ':send' will send all the accumulated inputs to the remote chain, one by one, and then leave the chain. Uses the parameter 'eval-definer' for eval redefinition, this should be a function which can be used to redefine 'eval': it should set eval to it's input.")
 
-;; Setup an eval definer
-(def boom
-  (quote
-   (do (def eval-ref (ref eval))
-       (def eval-definer (fn [f] (write-ref eval-ref f)))
-       (def eval (fn [e] ((read-ref eval-ref) e))))))
+;; TODO - update docs.
+;; TODO - should-bes.

--- a/rad/chain.rad
+++ b/rad/chain.rad
@@ -101,7 +101,9 @@
       (fn [expr env] 
           (if (eq? expr :send) 
               ;; (send! remote-chain inputs) 
-              (print! (view (.. (@ :env) (@ inputs)) env))
+              ;; TODO: reset inputs on send, so things don't get sent twice
+              (do (print! (view (.. (@ :env) (@ inputs)) env))
+                  (list :ok env))
               ((store-exprs oeval inputs) expr env)))))
 
 ;; enter-chain & enter-remote-chain

--- a/rad/chain.rad
+++ b/rad/chain.rad
@@ -10,7 +10,7 @@
    :inputs (list)
    :index 0})
 
-(def test-chain 
+(def test-chain
   {:state (pure-env)
    :inputs (list)
    :name "test"
@@ -30,12 +30,12 @@
           '(("expr" any) ("chain" chain))
           "Evaluates 'expr' in the 'chain' and returns a dict with the ':result' and the resulting ':chain'.")
 
-(do 
+((fn []
   (def res (eval-in-chain '(+ 3 2) empty-chain))
   (def ~~> (fn [comp expected] (should-be "eval-in-chain" (view comp res) expected)))
   (~~> (@ :result) 5)
   (~~> (.. (@ :chain) (@ :input)) '((+ 3 2)))
-  (~~> (.. (@ :chain) (@ :index)) 1))
+  (~~> (.. (@ :chain) (@ :index)) 1)))
 
 ;; update-chain-with
 
@@ -69,18 +69,15 @@
 ;; add-quit
 
 (def add-quit
-  (fn [old-state new-eval]
+  (fn [after-quit-state before-quit-eval]
     (fn [expr env]
       (if (eq? expr :quit)
-          (list :ok old-state)
-          (new-eval expr env)))))
+          (list :ok after-quit-state)
+          (before-quit-eval expr env)))))
 
-;; enter-chain
-
-;; TODO move else-where
-(def simple-eval
- (fn [expr]
-     (head (eval expr (get-current-env)))))
+(document 'add-quit
+          '(("after-quit-state" dict) ("before-quit-eval" fn))
+          "Adds a ':quit' command to 'before-quit-eval', which switches to 'after-quit-state' (and to the eval in that state)")
 
 ;; store-exprs
 
@@ -91,15 +88,15 @@
          (evalfn expr env_ ))))
 
 (document 'store-exprs
-          '(("eval" fn)) 
+          '(("eval" fn))
           "Store each new evaluated expression in '_inputs'")
 
 ;; add-send
 (def add-send
   (fn [oeval]
-      (fn [expr env] 
-          (if (eq? expr :send) 
-              (do (def inpl (.. (@ :env) (@ '_inputs))) 
+      (fn [expr env]
+          (if (eq? expr :send)
+              (do (def inpl (.. (@ :env) (@ '_inputs)))
                   (def chainl (.. (@ :env) (@ '_cur-chain)))
                   (map (fn [e] (send! (view chainl env) e)) (view inpl env))
                   (def env_ (set inpl [] env))
@@ -113,33 +110,35 @@
 ;; enter-chain & enter-remote-chain
 
 (def eval__ eval)
-(def-rec eval 
+(def-rec eval
   (fn [expr env]
       ;; The horror, the horror
-      (if (list? expr) 
-          (if (> (length expr) 0) 
-              (cond  
-                (eq? (head expr) :enter-chain) (do 
-                                                 (def arg (simple-eval (nth 1 expr)))
-                                                 (def mod-state 
-                                                   (over (.. (@ :env) (@ 'eval)) 
-                                                         (fn [x] (add-quit env x)) 
-                                                         (lookup :state arg))) 
-                                                 (list :ok mod-state)) 
-                (eq? (head expr) :enter-remote-chain) (do 
-                                                        (def arg (simple-eval (nth 1 expr)))
+      (if (list? expr)
+          (if (> (length expr) 0)
+              (cond
+                (eq? (head expr) :enter-chain) (do
+                                                 (def arg_ (nth 1 expr))
+                                                 (def arg (head (eval arg_ env)))
+                                                 (def mod-state
+                                                   (over (.. (@ :env) (@ 'eval))
+                                                         (fn [x] (add-quit env x))
+                                                         (lookup :state arg)))
+                                                 (list :ok mod-state))
+                (eq? (head expr) :enter-remote-chain) (do
+                                                        (def arg_ (nth 1 expr))
+                                                        (def arg (head (eval arg_ env)))
                                                         (def state (lookup :state arg))
                                                         (def mod-state1
                                                           (over (@ :env) (fn [x] (insert '_inputs [] x)) state))
                                                         (def mod-state2
-                                                          (over (@ :env) 
-                                                                (fn [x] (insert '_cur-chain (lookup :name arg) x)) 
+                                                          (over (@ :env)
+                                                                (fn [x] (insert '_cur-chain (lookup :name arg) x))
                                                                 mod-state1))
                                                         (def mod-state3
-                                                          (over (.. (@ :env) (@ 'eval)) 
-                                                                (fn [x] (add-send (add-quit (get-current-env) x))) 
-                                                                mod-state2)) 
-                                                        (list :ok mod-state3)) 
+                                                          (over (.. (@ :env) (@ 'eval))
+                                                                (fn [x] (add-send (add-quit (get-current-env) x)))
+                                                                mod-state2))
+                                                        (list :ok mod-state3))
                 :else (eval__ expr env))
               (eval__ expr env))
           (eval__ expr env))))

--- a/rad/chain.rad
+++ b/rad/chain.rad
@@ -84,20 +84,27 @@
      (head (eval expr (get-current-env)))))
 
 ;; store-exprs
+
 (def store-exprs
- (fn [eref evalfn]
+ (fn [evalfn key]
      (fn [expr env]
-         (modify-ref eref cons)
-         (evalfn expr env))))
+         (print! key)
+         (print! (view (.. (@ :env) (@ key)) env))
+         (print! env)
+         (def env_ (over (.. (@ :env) (@ key)) (fn [x] (add-right expr x)) env))
+         (evalfn expr env_ ))))
+
+(document 'store-exprs
+          '(("key" lens) ("eval" fn)) 
+          "Store each new evaluated expression in 'key'")
 
 ;; add-send
 (def add-send
-  (fn [oeval remote-chain]
-      (def expr-store (ref (list)))
+  (fn [oeval remote-chain inputs]
       (fn [expr env] 
           (if (eq? expr :send) 
-              (send! remote-chain (reverse (read-ref expr-store))) 
-              ((store-exprs expr-store oeval) expr env)))))
+              (send! remote-chain inputs) 
+              ((store-exprs oeval inputs) expr env)))))
 
 ;; enter-chain & enter-remote-chain
 
@@ -118,11 +125,16 @@
                 ;; Still broken
                 (eq? (head expr) :enter-remote-chain) (do 
                                                         (def arg (simple-eval (nth 1 expr)))
-                                                        (def mod-state 
+                                                        (def mod-state1
+                                                          (insert '_inputs [] (lookup :state arg))) 
+                                                        (def mod-state2
                                                           (over (.. (@ :env) (@ 'eval)) 
-                                                                (fn [x] (add-send (add-quit (get-current-env) x) arg)) 
-                                                                (lookup :state arg))) 
-                                                        (list :ok mod-state)) 
+                                                                (fn [x] (add-send 
+                                                                          (add-quit (get-current-env) x) 
+                                                                          arg 
+                                                                          '_inputs)) 
+                                                                mod-state1)) 
+                                                        (list :ok mod-state2)) 
                 :else (eval__ expr env))
               (eval__ expr env))
           (eval__ expr env))))

--- a/rad/chain.rad
+++ b/rad/chain.rad
@@ -55,16 +55,6 @@
           '(("chain" chain) ("chain-id" string) ("cb-expr" function) ("cb-res" function))
           "Updates 'chain' according to activity on the remote chain with ID 'chain-id', by pulling down and evaluating new inputs. Accepts two callbacks: 'cb-expr' is applied to the incoming expressions, and 'cb-res' is applied to the resulting values. Usually one uses 'print!' for both of these. If 'chain' is not a past version of the remote chain then the behaviour is unspecified.")
 
-;; set-topmost-st
-
-;; (def set-topmost-st
-;;   (fn [new-state]
-;;     (def once (fn [x y]
-;;       (def first? (ref #t))
-;;       (if (read-ref first?) x y))) 
-;;     (def  
-;;     (write-ref eval-ref 
-
 ;; add-quit
 
 (def add-quit
@@ -76,11 +66,6 @@
 
 ;; enter-chain
 
-
-;; (def test-chain 
-;;   (set (.. (@ :state) (@ :env) (@ 'eval)) (fn [expr env] (list #t env)) empty-chain ))  
-
-
 ;; TODO move else-where
 (def simple-eval
  (fn [expr]
@@ -89,24 +74,30 @@
 ;; store-exprs
 
 (def store-exprs
- (fn [evalfn key]
+ (fn [evalfn]
      (fn [expr env]
-         (def env_ (over (.. (@ :env) (@ key)) (fn [x] (add-right expr x)) env))
+         (def env_ (over (.. (@ :env) (@ '_inputs)) (fn [x] (add-right expr x)) env))
          (evalfn expr env_ ))))
 
 (document 'store-exprs
-          '(("key" lens) ("eval" fn)) 
-          "Store each new evaluated expression in 'key'")
+          '(("eval" fn)) 
+          "Store each new evaluated expression in '_inputs'")
 
 ;; add-send
 (def add-send
-  (fn [oeval remote-chain inputs]
+  (fn [oeval]
       (fn [expr env] 
           (if (eq? expr :send) 
-              (do (map (fn [e] (send! (view (.. (@ :env) (@ '_cur-chain)) env) e)) (view (.. (@ :env) (@ inputs)) env))
-                  (def env_ (set (.. (@ :env) (@ inputs)) [] env))
+              (do (def inpl (.. (@ :env) (@ '_inputs))) 
+                  (def chainl (.. (@ :env) (@ '_cur-chain)))
+                  (map (fn [e] (send! (view chainl env) e)) (view inpl env))
+                  (def env_ (set inpl [] env))
                   (list :ok env_))
-              ((store-exprs oeval inputs) expr env)))))
+              ((store-exprs oeval) expr env)))))
+
+(document 'add-send
+          '(("eval-fn" fn))
+          "Add a :send special form that sends the contents of _input to the chain _cur-chain")
 
 ;; enter-chain & enter-remote-chain
 
@@ -124,7 +115,6 @@
                                                          (fn [x] (add-quit env x)) 
                                                          (lookup :state arg))) 
                                                  (list :ok mod-state)) 
-                ;; Still broken
                 (eq? (head expr) :enter-remote-chain) (do 
                                                         (def arg (simple-eval (nth 1 expr)))
                                                         (def state (lookup :state arg))
@@ -136,41 +126,9 @@
                                                                 mod-state1))
                                                         (def mod-state3
                                                           (over (.. (@ :env) (@ 'eval)) 
-                                                                (fn [x] (add-send 
-                                                                          (add-quit (get-current-env) x) 
-                                                                          arg 
-                                                                          '_inputs)) 
+                                                                (fn [x] (add-send (add-quit (get-current-env) x))) 
                                                                 mod-state2)) 
                                                         (list :ok mod-state3)) 
                 :else (eval__ expr env))
               (eval__ expr env))
           (eval__ expr env))))
-
-;; enter-remote-chain
-
-(def enter-remote-chain
-  (fn [chain-id]
-    (def old-eval eval)
-    (def chain (update-chain-with empty-chain chain-id (fn [e] '()) (fn [e] '())))
-    (print! (string-append "Synced with remote chain, at index: " (show (view (@ :index) chain))))
-    (def ch (ref chain))
-    (def inputs (ref (list)))
-    (eval-definer
-     (fn [e]
-       (cond
-        (eq? e :quit) (do (print! "Leaving remote-chain.")
-                          (eval-definer old-eval))
-        (eq? e :send) (do (print! "Sending inputs to remote chain.")
-                          (map (fn [i] (send! chain-id i)) (reverse (read-ref inputs)))
-                          (print! "Done! Leaving remote-chain.")
-                          (eval-definer old-eval))
-        :else (do (def x (eval-in-chain e (read-ref ch)))
-                  (write-ref ch (view (@ :chain) x))
-                  (modify-ref inputs (fn [is] (cons e is)))
-                  (view (@ :result) x)))))))
-
-(document 'enter-remote-chain
-          '(("chain-id" string))
-          "Syncs up to a remote chain, and allows experimentation inputs. There are two special inputs: ':quit' will leave the chain, ':send' will send all the accumulated inputs to the remote chain, one by one, and then leave the chain. Uses the parameter 'eval-definer' for eval redefinition, this should be a function which can be used to redefine 'eval': it should set eval to it's input.")
-
-;; TODO - update docs.

--- a/rad/chain.rad
+++ b/rad/chain.rad
@@ -116,16 +116,33 @@
      (head (eval expr (get-current-env)))))
 
 ;; TODO: once you :quit, you can no longer :enter. Fix that
-(def eval 
+;; (def eval 
+;;   (fn [expr env]
+;;       (if (and (list? expr) (eq? (head expr) :enter-chain))
+;;           (do
+;;             (def mod-state 
+;;               (over (.. (@ :env) (@ 'eval)) 
+;;                     (fn [x] (add-quit (get-current-env) x))  
+;;                     (lookup :state (simple-eval (nth 1 expr)))))
+;;             (list :ok mod-state))
+;;           (eval expr env))))
+
+(def eval__ eval)
+(def-rec eval 
   (fn [expr env]
-      (if (and (list? expr) (eq? (head expr) :enter-chain))
-          (do
-            (def mod-state 
-              (over (.. (@ :env) (@ 'eval)) 
-                    (fn [x] (add-quit (get-current-env) x))  
-                    (lookup :state (simple-eval (nth 1 expr)))))
-            (list :ok mod-state))
-          (eval expr env))))
+      ;; The horror, the horror
+      (if (list? expr) 
+          (if (> (length expr) 0) 
+              (if (eq? (head expr) :enter-chain)
+                  (do
+                     (def mod-state 
+                       (over (.. (@ :env) (@ 'eval)) 
+                             (fn [x] (add-quit (get-current-env) x)) 
+                             (lookup :state (simple-eval (nth 1 expr)))))
+                     (list :ok mod-state))
+                  (eval__ expr env))
+              (eval__ expr env))
+          (eval__ expr env))))
 
 
 ;; enter-remote-chain

--- a/rad/chain.rad
+++ b/rad/chain.rad
@@ -55,6 +55,17 @@
           '(("chain" chain) ("chain-id" string) ("cb-expr" function) ("cb-res" function))
           "Updates 'chain' according to activity on the remote chain with ID 'chain-id', by pulling down and evaluating new inputs. Accepts two callbacks: 'cb-expr' is applied to the incoming expressions, and 'cb-res' is applied to the resulting values. Usually one uses 'print!' for both of these. If 'chain' is not a past version of the remote chain then the behaviour is unspecified.")
 
+;; update-chain
+
+(def update-chain
+  (fn [chain]
+    (def next (ref chain))
+    (update-chain-with chain (lookup :name chain) (fn [x] (modify-ref next (fn [r] (eval-in-chain x r)))) print!)))
+
+(document 'update-chain
+		  '(("chain" chain))
+		  "Return a version of 'chain' with new inputs and correspondingly updated state")
+
 ;; add-quit
 
 (def add-quit

--- a/rad/chain.rad
+++ b/rad/chain.rad
@@ -15,6 +15,8 @@
         :inputs (list)
         :index 0))
 
+;; eval-in-chain
+
 (def eval-in-chain
   (fn [expr chain]
     (def x (eval expr (lookup :state chain)))
@@ -28,9 +30,13 @@
           "Evaluates 'expr' in the 'chain' and returns a dict with the ':result' and the resulting ':chain'.")
 
 (do 
-  (def res (eval-in-chain (+ 3 2) empty-chain))
-  (def ~~> (fn [comp expected] (should-be "eval-in-chain" (lookup comp) expected)))
-  (~~> :result 5))
+  (def res (eval-in-chain '(+ 3 2) empty-chain))
+  (def ~~> (fn [comp expected] (should-be "eval-in-chain" (view comp res) expected)))
+  (~~> (@ :result) 5)
+  (~~> (.. (@ :chain) (@ :input)) '((+ 3 2)))
+  (~~> (.. (@ :chain) (@ :index)) 1))
+
+;; update-chain-with
 
 (def update-chain-with
   (fn [chain remote-chain-id cb-expr cb-res]
@@ -48,23 +54,33 @@
           '(("chain" chain) ("chain-id" string) ("cb-expr" function) ("cb-res" function))
           "Updates 'chain' according to activity on the remote chain with ID 'chain-id', by pulling down and evaluating new inputs. Accepts two callbacks: 'cb-expr' is applied to the incoming expressions, and 'cb-res' is applied to the resulting values. Usually one uses 'print!' for both of these. If 'chain' is not a past version of the remote chain then the behaviour is unspecified.")
 
+;; enter-chain
+
 (def enter-chain
   (fn [chain]
     (def old-eval eval)
     (def ch (ref chain))
     (def ev
-      (fn [e]
+      (fn [e env]
         (if (eq? e :quit)
             (do (print! "leaving chain")
                 (eval-definer old-eval))
           (do (def x (eval e (read-ref ch)))
               (write-ref ch (view (@ :chain) x))
-              (view (@ :result) x)))))
+              (list (view (@ :result) x) env)))))
     (eval-definer ev)))
 
 (document 'enter-chain
           '(("chain" chain))
           "Instantiates an 'eval' which evaluates expressions in 'chain'. The expression ':quit' will return to the previous eval. Uses the parameter 'eval-definer' for eval redefinition, this should be a function which can be used to redefine 'eval': it should set eval to it's input.")
+
+(do 
+  (enter-chain empty-chain)
+  (def eval (fn [expr env] (list #t env)))
+  :quit
+  (should-be "enter-chain" #f #f))
+
+;; enter-remote-chain
 
 (def enter-remote-chain
   (fn [chain-id]

--- a/rad/chain.rad
+++ b/rad/chain.rad
@@ -11,7 +11,10 @@
    :index 0})
 
 (def test-chain 
-  (set (... (list (@ :state) (@ :env) (@ 'eval))) (fn [expr env] (list #t env)) empty-chain) )  
+  {:state (pure-env)
+   :inputs (list)
+   :name "test"
+   :index 0})
 
 ;; eval-in-chain
 
@@ -100,10 +103,9 @@
   (fn [oeval remote-chain inputs]
       (fn [expr env] 
           (if (eq? expr :send) 
-              ;; (send! remote-chain inputs) 
-              ;; TODO: reset inputs on send, so things don't get sent twice
-              (do (print! (view (.. (@ :env) (@ inputs)) env))
-                  (list :ok env))
+              (do (map (fn [e] (send! (view (.. (@ :env) (@ '_cur-chain)) env) e)) (view (.. (@ :env) (@ inputs)) env))
+                  (def env_ (set (.. (@ :env) (@ inputs)) [] env))
+                  (list :ok env_))
               ((store-exprs oeval inputs) expr env)))))
 
 ;; enter-chain & enter-remote-chain
@@ -119,7 +121,7 @@
                                                  (def arg (simple-eval (nth 1 expr)))
                                                  (def mod-state 
                                                    (over (.. (@ :env) (@ 'eval)) 
-                                                         (fn [x] (add-quit (get-current-env) x)) 
+                                                         (fn [x] (add-quit env x)) 
                                                          (lookup :state arg))) 
                                                  (list :ok mod-state)) 
                 ;; Still broken
@@ -129,13 +131,17 @@
                                                         (def mod-state1
                                                           (over (@ :env) (fn [x] (insert '_inputs [] x)) state))
                                                         (def mod-state2
+                                                          (over (@ :env) 
+                                                                (fn [x] (insert '_cur-chain (lookup :name arg) x)) 
+                                                                mod-state1))
+                                                        (def mod-state3
                                                           (over (.. (@ :env) (@ 'eval)) 
                                                                 (fn [x] (add-send 
                                                                           (add-quit (get-current-env) x) 
                                                                           arg 
                                                                           '_inputs)) 
-                                                                mod-state1)) 
-                                                        (list :ok mod-state2)) 
+                                                                mod-state2)) 
+                                                        (list :ok mod-state3)) 
                 :else (eval__ expr env))
               (eval__ expr env))
           (eval__ expr env))))

--- a/rad/chain.rad
+++ b/rad/chain.rad
@@ -6,8 +6,11 @@
 ;;   - A sequence of inputs.
 
 
+;; TODO
 ;; DELETEME
-(def eval-definer (fn [ev] (write-ref eval ev)))
+(def eval-ref (ref eval)) 
+(def eval (fn [expr env] ((read-ref eval-ref) expr env)))
+(def eval-definer (fn [ev] (write-ref eval-ref ev)))
 ;; DELETEME
 
 (def empty-chain
@@ -108,4 +111,5 @@
           "Syncs up to a remote chain, and allows experimentation inputs. There are two special inputs: ':quit' will leave the chain, ':send' will send all the accumulated inputs to the remote chain, one by one, and then leave the chain. Uses the parameter 'eval-definer' for eval redefinition, this should be a function which can be used to redefine 'eval': it should set eval to it's input.")
 
 ;; TODO - update docs.
-;; TODO - should-bes.
+;; TODO - eval as ref
+;; TODO - get rid of eval-definer and stuff above

--- a/rad/chain.rad
+++ b/rad/chain.rad
@@ -5,18 +5,18 @@
 ;;     == base-eval')
 ;;   - A sequence of inputs.
 
+;; TODO do we want this? then move it
+;; (def eval-ref (ref eval))
+;; (def eval (fn [expr env] ((read-ref eval-ref) expr env)))
 
-;; TODO
-;; DELETEME
-(def eval-ref (ref eval)) 
-(def eval (fn [expr env] ((read-ref eval-ref) expr env)))
-(def eval-definer (fn [ev] (write-ref eval-ref ev)))
-;; DELETEME
 
 (def empty-chain
-  (dict :state (pure-env)
-        :inputs (list)
-        :index 0))
+  {:state (pure-env)
+   :inputs (list)
+   :index 0})
+
+(def test-chain 
+  (set (... (list (@ :state) (@ :env) (@ 'eval))) (fn [expr env] (list #t env)) empty-chain) )  
 
 ;; eval-in-chain
 
@@ -57,31 +57,76 @@
           '(("chain" chain) ("chain-id" string) ("cb-expr" function) ("cb-res" function))
           "Updates 'chain' according to activity on the remote chain with ID 'chain-id', by pulling down and evaluating new inputs. Accepts two callbacks: 'cb-expr' is applied to the incoming expressions, and 'cb-res' is applied to the resulting values. Usually one uses 'print!' for both of these. If 'chain' is not a past version of the remote chain then the behaviour is unspecified.")
 
+;; set-topmost-st
+
+;; (def set-topmost-st
+;;   (fn [new-state]
+;;     (def once (fn [x y]
+;;       (def first? (ref #t))
+;;       (if (read-ref first?) x y))) 
+;;     (def  
+;;     (write-ref eval-ref 
+
+;; add-quit
+
+(def add-quit
+  (fn [old-state new-eval]
+    (fn [expr env]
+      (if (eq? expr :quit)
+          (list :ok old-state)
+          (new-eval expr env)))))
+
 ;; enter-chain
 
-(def enter-chain
-  (fn [chain]
-    (def old-eval eval)
-    (def ch (ref chain))
-    (def ev
-      (fn [e env]
-        (if (eq? e :quit)
-            (do (print! "leaving chain")
-                (eval-definer old-eval))
-          (do (def x (eval e (read-ref ch)))
-              (write-ref ch (view (@ :chain) x))
-              (list (view (@ :result) x) env)))))
-    (eval-definer ev)))
 
-(document 'enter-chain
-          '(("chain" chain))
-          "Instantiates an 'eval' which evaluates expressions in 'chain'. The expression ':quit' will return to the previous eval. Uses the parameter 'eval-definer' for eval redefinition, this should be a function which can be used to redefine 'eval': it should set eval to it's input.")
+;; (def test-chain 
+;;   (set (.. (@ :state) (@ :env) (@ 'eval)) (fn [expr env] (list #t env)) empty-chain ))  
 
-(do 
-  (enter-chain empty-chain)
-  (def eval (fn [expr env] (list #t env)))
-  :quit
-  (should-be "enter-chain" #f #f))
+
+;; (def enter-chain
+;;   (fn [chain]
+;;     (def old-eval eval)
+;;     (def ch (ref chain))
+;;     (add-quit old-eval  
+;;     (def ev
+;;       (fn [e env]
+;;         (print! e)
+;;         (if (eq? e :quit)
+;;             (do (print! "leaving chain")
+;;                 (list :ok old-state))
+;;           (do (def x (eval e (read-ref ch)))
+;;               (write-ref ch (view (@ :chain) x))
+;;               (list (view (@ :result) x) env)))))
+;;     (print! "here")
+;;     (write-ref eval-ref ev)))
+;; 
+;; (document 'enter-chain
+;;           '(("chain" chain))
+;;           "Instantiates an 'eval' which evaluates expressions in 'chain'. The expression ':quit' will return to the previous eval. Uses the parameter 'eval-definer' for eval redefinition, this should be a function which can be used to redefine 'eval': it should set eval to it's input.")
+;; 
+;; (do 
+;;   (enter-chain empty-chain)
+;;   (def eval (fn [expr env] (list #t env)))
+;;   :quit
+;;   (should-be "enter-chain" #f #f))
+
+;; TODO move else-where
+(def simple-eval
+ (fn [expr]
+     (head (eval expr (get-current-env)))))
+
+;; TODO: once you :quit, you can no longer :enter. Fix that
+(def eval 
+  (fn [expr env]
+      (if (and (list? expr) (eq? (head expr) :enter-chain))
+          (do
+            (def mod-state 
+              (over (.. (@ :env) (@ 'eval)) 
+                    (fn [x] (add-quit (get-current-env) x))  
+                    (lookup :state (simple-eval (nth 1 expr)))))
+            (list :ok mod-state))
+          (eval expr env))))
+
 
 ;; enter-remote-chain
 

--- a/rad/chain.rad
+++ b/rad/chain.rad
@@ -87,16 +87,17 @@
 (def store-exprs
  (fn [eref evalfn]
      (fn [expr env]
-         (modify-ref cons eref)
+         (modify-ref eref cons)
          (evalfn expr env))))
 
 ;; add-send
 (def add-send
   (fn [oeval remote-chain]
       (def expr-store (ref (list)))
-      (if (eq? expr :send)
-          (send! remote-chain (reverse (read-ref expr-store)))
-          (store-exprs expr-store oeval ))))
+      (fn [expr env] 
+          (if (eq? expr :send) 
+              (send! remote-chain (reverse (read-ref expr-store))) 
+              ((store-exprs expr-store oeval) expr env)))))
 
 ;; enter-chain & enter-remote-chain
 

--- a/rad/chain.rad
+++ b/rad/chain.rad
@@ -88,9 +88,6 @@
 (def store-exprs
  (fn [evalfn key]
      (fn [expr env]
-         (print! key)
-         (print! (view (.. (@ :env) (@ key)) env))
-         (print! env)
          (def env_ (over (.. (@ :env) (@ key)) (fn [x] (add-right expr x)) env))
          (evalfn expr env_ ))))
 
@@ -103,7 +100,8 @@
   (fn [oeval remote-chain inputs]
       (fn [expr env] 
           (if (eq? expr :send) 
-              (send! remote-chain inputs) 
+              ;; (send! remote-chain inputs) 
+              (print! (view (.. (@ :env) (@ inputs)) env))
               ((store-exprs oeval inputs) expr env)))))
 
 ;; enter-chain & enter-remote-chain
@@ -125,8 +123,9 @@
                 ;; Still broken
                 (eq? (head expr) :enter-remote-chain) (do 
                                                         (def arg (simple-eval (nth 1 expr)))
+                                                        (def state (lookup :state arg))
                                                         (def mod-state1
-                                                          (insert '_inputs [] (lookup :state arg))) 
+                                                          (over (@ :env) (fn [x] (insert '_inputs [] x)) state))
                                                         (def mod-state2
                                                           (over (.. (@ :env) (@ 'eval)) 
                                                                 (fn [x] (add-send 

--- a/rad/chain.rad
+++ b/rad/chain.rad
@@ -5,11 +5,6 @@
 ;;     == base-eval')
 ;;   - A sequence of inputs.
 
-;; TODO do we want this? then move it
-;; (def eval-ref (ref eval))
-;; (def eval (fn [expr env] ((read-ref eval-ref) expr env)))
-
-
 (def empty-chain
   {:state (pure-env)
    :inputs (list)
@@ -83,49 +78,27 @@
 ;;   (set (.. (@ :state) (@ :env) (@ 'eval)) (fn [expr env] (list #t env)) empty-chain ))  
 
 
-;; (def enter-chain
-;;   (fn [chain]
-;;     (def old-eval eval)
-;;     (def ch (ref chain))
-;;     (add-quit old-eval  
-;;     (def ev
-;;       (fn [e env]
-;;         (print! e)
-;;         (if (eq? e :quit)
-;;             (do (print! "leaving chain")
-;;                 (list :ok old-state))
-;;           (do (def x (eval e (read-ref ch)))
-;;               (write-ref ch (view (@ :chain) x))
-;;               (list (view (@ :result) x) env)))))
-;;     (print! "here")
-;;     (write-ref eval-ref ev)))
-;; 
-;; (document 'enter-chain
-;;           '(("chain" chain))
-;;           "Instantiates an 'eval' which evaluates expressions in 'chain'. The expression ':quit' will return to the previous eval. Uses the parameter 'eval-definer' for eval redefinition, this should be a function which can be used to redefine 'eval': it should set eval to it's input.")
-;; 
-;; (do 
-;;   (enter-chain empty-chain)
-;;   (def eval (fn [expr env] (list #t env)))
-;;   :quit
-;;   (should-be "enter-chain" #f #f))
-
 ;; TODO move else-where
 (def simple-eval
  (fn [expr]
      (head (eval expr (get-current-env)))))
 
-;; TODO: once you :quit, you can no longer :enter. Fix that
-;; (def eval 
-;;   (fn [expr env]
-;;       (if (and (list? expr) (eq? (head expr) :enter-chain))
-;;           (do
-;;             (def mod-state 
-;;               (over (.. (@ :env) (@ 'eval)) 
-;;                     (fn [x] (add-quit (get-current-env) x))  
-;;                     (lookup :state (simple-eval (nth 1 expr)))))
-;;             (list :ok mod-state))
-;;           (eval expr env))))
+;; store-exprs
+(def store-exprs
+ (fn [eref evalfn]
+     (fn [expr env]
+         (modify-ref cons eref)
+         (evalfn expr env))))
+
+;; add-send
+(def add-send
+  (fn [oeval remote-chain]
+      (def expr-store (ref (list)))
+      (if (eq? expr :send)
+          (send! remote-chain (reverse (read-ref expr-store)))
+          (store-exprs expr-store oeval ))))
+
+;; enter-chain & enter-remote-chain
 
 (def eval__ eval)
 (def-rec eval 
@@ -133,17 +106,25 @@
       ;; The horror, the horror
       (if (list? expr) 
           (if (> (length expr) 0) 
-              (if (eq? (head expr) :enter-chain)
-                  (do
-                     (def mod-state 
-                       (over (.. (@ :env) (@ 'eval)) 
-                             (fn [x] (add-quit (get-current-env) x)) 
-                             (lookup :state (simple-eval (nth 1 expr)))))
-                     (list :ok mod-state))
-                  (eval__ expr env))
+              (cond  
+                (eq? (head expr) :enter-chain) (do 
+                                                 (def arg (simple-eval (nth 1 expr)))
+                                                 (def mod-state 
+                                                   (over (.. (@ :env) (@ 'eval)) 
+                                                         (fn [x] (add-quit (get-current-env) x)) 
+                                                         (lookup :state arg))) 
+                                                 (list :ok mod-state)) 
+                ;; Still broken
+                (eq? (head expr) :enter-remote-chain) (do 
+                                                        (def arg (simple-eval (nth 1 expr)))
+                                                        (def mod-state 
+                                                          (over (.. (@ :env) (@ 'eval)) 
+                                                                (fn [x] (add-send (add-quit (get-current-env) x) arg)) 
+                                                                (lookup :state arg))) 
+                                                        (list :ok mod-state)) 
+                :else (eval__ expr env))
               (eval__ expr env))
           (eval__ expr env))))
-
 
 ;; enter-remote-chain
 
@@ -173,5 +154,3 @@
           "Syncs up to a remote chain, and allows experimentation inputs. There are two special inputs: ':quit' will leave the chain, ':send' will send all the accumulated inputs to the remote chain, one by one, and then leave the chain. Uses the parameter 'eval-definer' for eval redefinition, this should be a function which can be used to redefine 'eval': it should set eval to it's input.")
 
 ;; TODO - update docs.
-;; TODO - eval as ref
-;; TODO - get rid of eval-definer and stuff above

--- a/rad/prelude/dict.rad
+++ b/rad/prelude/dict.rad
@@ -30,6 +30,19 @@
 ;;            '(:one :two))
 
 
+;; rekey
+(def rekey (fn [old-key new-key mp]
+  (def old-val (lookup old-key mp))
+  (delete old-key (insert new-key old-val mp)))) 
+
+(document 'rekey
+  '(("old-key" any) ("new-key" any) ("dict" dict))
+  "Change the key from 'old-key' to 'new-key' in 'dict'. If 'new-key' already exists, it is overwritten.")
+
+(should-be "rekey"
+           (rekey :a :b {:a 5})
+           {:b 5})
+
 ;; modify-map
 (def modify-map (fn [key f mp]
   (insert key (f (lookup key mp)) mp)))

--- a/rad/prelude/should-be.rad
+++ b/rad/prelude/should-be.rad
@@ -4,7 +4,9 @@
   (fn [name x y]
     (if (eq? x y)
         (print! (string-append "Test '" name "' succeeded"))
-      (print! (string-append "Test '" name "' failed")))))
+        (do 
+          (print! (string-append "Test '" name "' failed"))
+          (print! (string-append "LHS:\n\t" (show x) "\nRHS:\n\t" (show y)))))))
 
 (document 'should-be
   '(("test-name" string) ("actual" any) ("expected" any))

--- a/src/Radicle/Internal/PrimFns.hs
+++ b/src/Radicle/Internal/PrimFns.hs
@@ -89,7 +89,7 @@ purePrimFns = PrimFns $ fromList $ first Ident <$>
     , ( "add-right"
       , twoArg "add-right" $ \case
           (x, Vec xs) -> pure $ Vec (xs Seq.:|> x)
-          _ -> throwErrorHere $ TypeError "add-left: second argument must be a vector"
+          _ -> throwErrorHere $ TypeError "add-right: second argument must be a vector"
       )
 
     -- Lists

--- a/src/Radicle/Internal/PrimFns.hs
+++ b/src/Radicle/Internal/PrimFns.hs
@@ -140,6 +140,10 @@ purePrimFns = PrimFns $ fromList $ first Ident <$>
           [_, _, _]                -> throwErrorHere
                                     $ TypeError "insert: third argument must be a dict"
           xs -> throwErrorHere $ WrongNumberOfArgs "insert" 3 (length xs))
+    , ("delete", \case
+          [k, Dict m] -> pure . Dict $ Map.delete k m
+          [_, _]      -> throwErrorHere $ TypeError "delete: second argument must be a dict"
+          xs          -> throwErrorHere $ WrongNumberOfArgs "delete" 2 (length xs))
     -- The semantics of + and - in Scheme is a little messed up. (+ 3)
     -- evaluates to 3, and of (- 3) to -3. That's pretty intuitive.
     -- But while (+ 3 2 1) evaluates to 6, (- 3 2 1) evaluates to 0. So with -

--- a/src/Radicle/Internal/PrimFns.hs
+++ b/src/Radicle/Internal/PrimFns.hs
@@ -175,7 +175,8 @@ purePrimFns = PrimFns $ fromList $ first Ident <$>
           xs                   -> throwErrorHere $ WrongNumberOfArgs "foldr" 3 (length xs))
     , ("map", \case
           [fn, List ls] -> List <$> traverse (callFn fn) (pure <$> ls)
-          [_, _]        -> throwErrorHere $ TypeError "map: second argument should be a list"
+          [fn, Vec ls]  -> Vec <$> traverse (callFn fn) (pure <$> ls)
+          [_, _]        -> throwErrorHere $ TypeError "map: second argument should be a list or vector"
           xs            -> throwErrorHere $ WrongNumberOfArgs "map" 3 (length xs))
     , ("keyword?", oneArg "keyword?" $ \case
           Keyword _ -> pure tt

--- a/test/spec/Radicle/Tests.hs
+++ b/test/spec/Radicle/Tests.hs
@@ -644,6 +644,24 @@ test_repl =
                      ]
         (_, result) <- runInRepl input
         result @==> output
+
+    , testCase "'enter-chain' changes environment" $ do
+        let input = [ "(def x 0)"
+                    , "(:enter-chain empty-chain)"
+                    , "(def x 1)"
+                    , "x"
+                    , ":quit"
+                    , "x"
+                    ]
+            output = [ "()"
+                     , ":ok"
+                     , "()"
+                     , "1.0"
+                     , ":ok"
+                     , "0.0"
+                     ]
+        (_, result) <- runInRepl input
+        result @==> output
     ]
     where
       -- In addition to the output of the lines tested, 'should-be's get


### PR DESCRIPTION
Some radicle files (in particular `chains.rad`) had become outdated after the new eval change. This PR updates them to work. Notable changes:

- The problem where defs wouldn't work after leaving a chain is now fixed
- `enter-chain` and `enter-remote-chain` are now special forms defined by an eval redefinition. They now have the form `(:enter-chain <chain>)` or `(:enter-remote-chain <chain>)`. 
- `:send` does not imply `:quit`

Changes that I also made that aren't directly related to entering chains:

- `map` now works with vectors
- Added `delete` primfn for dicts
- Added `rekey` function
- Show failure details in `should-be`

Still todo:

- [x] Clean up linger todos in `chain.rad`
- [x] `update-chain`
- [x] Finish up relevant docs section