### PR TITLE
Improve XDG files

### DIFF
--- a/exe/Repl/Main.hs
+++ b/exe/Repl/Main.hs
@@ -9,11 +9,11 @@ main :: IO ()
 main = do
     opts' <- execParser allOpts
     cfgFile <- case configFile opts' of
-        Nothing  -> getConfig
+        Nothing  -> getConfigFile
         Just cfg -> pure cfg
     cfgSrc <- readFile cfgFile
     hist <- case histFile opts' of
-        Nothing -> getHistory
+        Nothing -> getHistoryFile
         Just h  -> pure h
     repl (Just hist) (toS cfgFile) cfgSrc replBindings
   where

--- a/exe/Server/Client.hs
+++ b/exe/Server/Client.hs
@@ -15,11 +15,11 @@ main :: IO ()
 main = do
     opts' <- execParser allOpts
     cfgFile <- case configFile opts' of
-        Nothing  -> getConfig
+        Nothing  -> getConfigFile
         Just cfg -> pure cfg
     cfgSrc <- readFile cfgFile
     hist <- case histFile opts' of
-        Nothing -> getHistory
+        Nothing -> getHistoryFile
         Just h  -> pure h
     mgr <- newManager defaultManagerSettings
     let cEnv = mkClientEnv mgr (serverURL opts')

--- a/src/Radicle.hs
+++ b/src/Radicle.hs
@@ -82,8 +82,8 @@ module Radicle
     , ReplM
 
     -- * CLI
-    , getConfig
-    , getHistory
+    , getConfigFile
+    , getHistoryFile
 
     -- * Helpers
     , quote

--- a/src/Radicle/Internal/CLI.hs
+++ b/src/Radicle/Internal/CLI.hs
@@ -7,7 +7,6 @@ where
 import           Protolude
 import           System.Directory (XdgDirectory(..), getXdgDirectory)
 
--- | Uses XDG_CONFIG_HOME if available.
 -- | Location of the radicle file to interpret.
 -- Usually @~/.local/config/radicle/config.rad@.
 --

--- a/src/Radicle/Internal/CLI.hs
+++ b/src/Radicle/Internal/CLI.hs
@@ -1,6 +1,6 @@
 module Radicle.Internal.CLI
-    ( getConfig
-    , getHistory
+    ( getConfigFile
+    , getHistoryFile
     )
 where
 
@@ -8,9 +8,18 @@ import           Protolude
 import           System.Directory (XdgDirectory(..), getXdgDirectory)
 
 -- | Uses XDG_CONFIG_HOME if available.
-getConfig :: IO FilePath
-getConfig = getXdgDirectory XdgConfig "rad/config.rad"
+-- | Location of the default radicle file to interpretradicle history.
+-- Usually @~/.local/config/radicle/config.rad@.
+--
+-- See 'getXdgDirectory' XdgConfig' for how @~/.local/share@ is
+-- determined.
+getConfigFile :: IO FilePath
+getConfigFile = getXdgDirectory XdgConfig "radicle/config.rad"
 
--- | Uses XDG_CACHE_HOME if available.
-getHistory :: IO FilePath
-getHistory = getXdgDirectory XdgData "rad/config.rad"
+-- | Location of the radicle history. Usually
+-- @~/.local/share/radicle/history@.
+--
+-- See 'getXdgDirectory' 'XdgData' for how @~/.local/share@ is
+-- determined.
+getHistoryFile :: IO FilePath
+getHistoryFile = getXdgDirectory XdgData "radicle/history"

--- a/src/Radicle/Internal/CLI.hs
+++ b/src/Radicle/Internal/CLI.hs
@@ -8,7 +8,7 @@ import           Protolude
 import           System.Directory (XdgDirectory(..), getXdgDirectory)
 
 -- | Uses XDG_CONFIG_HOME if available.
--- | Location of the default radicle file to interpretradicle history.
+-- | Location of the radicle file to interpret.
 -- Usually @~/.local/config/radicle/config.rad@.
 --
 -- See 'getXdgDirectory' XdgConfig' for how @~/.local/share@ is


### PR DESCRIPTION
* Fix path for history file.
* Switch to more explicit `radicle` directory.
* Improve naming by appending `file` to exports.
* Improve documentation.