### PR TITLE
Add 'addPrimFns' function

### DIFF
--- a/exe/Server/Client.hs
+++ b/exe/Server/Client.hs
@@ -64,17 +64,10 @@ opts = Opts
 -- * Primops
 
 bindings :: ClientEnv -> Bindings (PrimFns (InputT IO))
-bindings cEnv
-    = e { bindingsPrimFns = bindingsPrimFns e <> prims
-        , bindingsEnv = bindingsEnv e <> primFnsEnv prims
-        }
-  where
-    e :: Bindings (PrimFns (InputT IO))
-    e = replBindings
-    prims = primops cEnv
+bindings cEnv = addPrimFns (replPrimFns <> clientPrimFns cEnv) pureEnv
 
-primops :: ClientEnv -> PrimFns (InputT IO)
-primops cEnv = PrimFns (fromList [sendPrimop, receivePrimop])
+clientPrimFns :: ClientEnv -> PrimFns (InputT IO)
+clientPrimFns cEnv = PrimFns (fromList [sendPrimop, receivePrimop])
   where
     sendPrimop =
       ( unsafeToIdent "send!"

--- a/src/Radicle.hs
+++ b/src/Radicle.hs
@@ -78,7 +78,7 @@ module Radicle
     , PrimFns(..)
     , purePrimFns
     , replPrimFns
-    , primFnsEnv
+    , addPrimFns
     , ReplM
 
     -- * CLI

--- a/src/Radicle/Internal/Core.hs
+++ b/src/Radicle/Internal/Core.hs
@@ -372,7 +372,7 @@ lookupAtom i = get >>= \e -> case Map.lookup i . fromEnv $ bindingsEnv e of
 -- | Lookup a primop.
 lookupPrimop :: Monad m => Ident -> Lang m ([Value] -> Lang m Value)
 lookupPrimop i = get >>= \e -> case Map.lookup i $ getPrimFns $ bindingsPrimFns e of
-    Nothing -> throwErrorHere $ Impossible "Unknown primop"
+    Nothing -> throwErrorHere $ Impossible $ "Unknown primop " <> fromIdent i
     Just v  -> pure v
 
 defineAtom :: Monad m => Ident -> Value -> Lang m ()

--- a/src/Radicle/Internal/Core.hs
+++ b/src/Radicle/Internal/Core.hs
@@ -297,7 +297,7 @@ instance GhcExts.IsList (Env s) where
 
 -- | Primop mappings. The parameter specifies the monad the primops run in.
 newtype PrimFns m = PrimFns { getPrimFns :: Map Ident ([Value] -> Lang m Value) }
-  deriving (Semigroup)
+  deriving (Semigroup, Monoid)
 
 -- | Bindings, either from the env or from the primops.
 data Bindings prims = Bindings

--- a/src/Radicle/Internal/Effects.hs
+++ b/src/Radicle/Internal/Effects.hs
@@ -70,13 +70,7 @@ completion = completeWord Nothing ['(', ')', ' ', '\n'] go
         <> Map.keys (getPrimFns $ bindingsPrimFns bnds)
 
 replBindings :: forall m. ReplM m => Bindings (PrimFns m)
-replBindings = e { bindingsPrimFns = bindingsPrimFns e <> replPrimFns
-                 , bindingsEnv = bindingsEnv e <> primFnsEnv pfs }
-    where
-      e :: Bindings (PrimFns m)
-      e = pureEnv
-      pfs :: PrimFns m
-      pfs = replPrimFns
+replBindings = addPrimFns replPrimFns pureEnv
 
 replPrimFns :: forall m. ReplM m => PrimFns m
 replPrimFns = PrimFns . Map.fromList $ first unsafeToIdent <$>


### PR DESCRIPTION
The `addPrimFns` function replaces the use of `primFnsEnv` and
simplifies creating bindings with a given set of primitive functions.

We also add a `Monoid` instance for `PrimFns` that allows us to use
`mempty` for an empty set of primitives functions.

We also include unknown primop in error messages.