### PR TITLE
Improve chain API

### DIFF
--- a/docs/source/guide/Chains.lrad
+++ b/docs/source/guide/Chains.lrad
@@ -1,15 +1,5 @@
 # Chains
 
-(N.B.: for this section, you should use the `radicle-client` executable rather
-than the `radicle` one. The simplest way to run it is to pass `radicle.xyz` as
-the `url` argument:
-
-```
-radicle-client --config rad/repl.rad --url radicle.xyz
-```
-
-In the future `radicle-client` and `radicle` will be folded into one.)
-
 By now you've seen some of `radicle`, but we haven't touched upon what makes it
 different from other languages.
 
@@ -36,14 +26,14 @@ TODO: more.
 First we start up a simple server that hosts remote chains on port 8000.
 
 ```
-stack exec -- radicle-server
+stack run -- radicle-server
 ```
 
 Now we can start a radicle REPL that will be able to communicate with
 the remote chain.
 
 ```
-stack exec -- radicle-client --config rad/repl.rad
+stack run -- radicle-client rad/repl.rad
 ```
 
 We start of by sending an expression to the chain that defines the atom `foo`.
@@ -73,7 +63,7 @@ Next we will use `:enter-chain` to evaluate and send expressions to the
 remote chain.
 
 ```
-(:enter-chain "http://localhost:8023/chains/my-first-chain")
+(:enter-chain "http://localhost:8000/chains/my-first-chain")
 (def bar foo)
 (def quux 4)
 :send  ;; ==> :ok

--- a/exe/RadicleExe.hs
+++ b/exe/RadicleExe.hs
@@ -99,7 +99,7 @@ clientPrimFns mgr = fromList . PrimFns.allDocs $ [sendPrimop, receivePrimop]
              case res of
                  Left e   -> throwErrorHere . OtherError
                            $ "send!: failed:" <> show e
-                 Right () -> pure $ List []
+                 Right r  -> pure r
          [_, _] -> throwErrorHere $ TypeError "send!: first argument should be a string"
          xs     -> throwErrorHere $ WrongNumberOfArgs "send!" 2 (length xs)
       )
@@ -116,7 +116,7 @@ clientPrimFns mgr = fromList . PrimFns.allDocs $ [sendPrimop, receivePrimop]
                       liftIO (runClientM' url mgr (since r)) >>= \case
                           Left err -> throwErrorHere . OtherError
                                     $ "receive!: request failed:" <> show err
-                          Right v' -> pure $ List v'
+                          Right v' -> pure v'
           [String _, _] -> throwErrorHere $ TypeError "receive!: expecting number as second arg"
           [_, _]        -> throwErrorHere $ TypeError "receive!: expecting string as first arg"
           xs            -> throwErrorHere $ WrongNumberOfArgs "receive!" 2 (length xs)
@@ -124,10 +124,10 @@ clientPrimFns mgr = fromList . PrimFns.allDocs $ [sendPrimop, receivePrimop]
 
 -- * Client functions
 
-submit :: Value -> ClientM ()
+submit :: Value -> ClientM Value
 submit = client chainSubmitEndpoint
 
-since :: Int -> ClientM [Value]
+since :: Int -> ClientM Value
 since = client chainSinceEndpoint
 
 runClientM' :: (MonadThrow m, MonadIO m) => Text -> HttpClient.Manager -> ClientM a -> m (Either ServantError a)


### PR DESCRIPTION
We stop using the`Show` and `Read` instances to serialise Radicle values for the plaintext MIME type. Instead we render the radicle values as code and parse them as code.

This also changes the contract of the `since` endpoint. Now we return the expresssions as a list of Radicle values.