### PR TITLE
Cleanup usage of file argument in CLI

### DIFF
--- a/src/Radicle.hs
+++ b/src/Radicle.hs
@@ -82,7 +82,6 @@ module Radicle
     , ReplM
 
     -- * CLI
-    , getConfigFile
     , getHistoryFile
 
     -- * Helpers

--- a/src/Radicle/Internal/CLI.hs
+++ b/src/Radicle/Internal/CLI.hs
@@ -1,6 +1,5 @@
 module Radicle.Internal.CLI
-    ( getConfigFile
-    , getHistoryFile
+    ( getHistoryFile
     )
 where
 
@@ -8,14 +7,6 @@ import           Protolude
 import           System.Directory
                  (XdgDirectory(..), createDirectoryIfMissing, getXdgDirectory)
 import           System.FilePath (takeDirectory)
-
--- | Location of the radicle file to interpret.
--- Usually @~/.local/config/radicle/config.rad@.
---
--- See 'getXdgDirectory' XdgConfig' for how @~/.local/share@ is
--- determined.
-getConfigFile :: IO FilePath
-getConfigFile = getXdgDirectory XdgConfig "radicle/config.rad"
 
 -- | Location of the radicle history, usually
 -- @~/.local/share/radicle/history@.


### PR DESCRIPTION
Omitting the `FILE` argument from the CLI never worked. We undocument that functionality and remove all code related to it.