### PR TITLE
Fix issue #16, in which identifiers with numeric prefixes are generated

### DIFF
--- a/src/Radicle/Internal.hs
+++ b/src/Radicle/Internal.hs
@@ -23,9 +23,9 @@ import qualified Text.Megaparsec as M
 
 -- | Smart constructor for Ident.
 mkIdent :: Text -> Maybe Ident
-mkIdent t = case runIdentity (M.runParserT identP "" t) of
-    Left _  -> Nothing
-    Right v -> pure v
+mkIdent t = case runIdentity (M.runParserT valueP "" t) of
+    Right (Atom i) -> pure i
+    _              -> Nothing
 
 -- | A quasiquoter that checks that an identifier is valid at compile-time.
 ident :: QuasiQuoter

--- a/test/spec/Radicle/Tests.hs
+++ b/test/spec/Radicle/Tests.hs
@@ -538,6 +538,11 @@ test_parser =
 
     , testCase "a dict litteral with an odd number of forms is a syntax error" $
         assertBool "succesfully parsed a dict with 3 forms" (isLeft $ parseTest "{:foo 3 4}")
+
+    , testCase "mkIdent does not accept identifiers with numeric prefixes" $ do
+        assertBool "not for -93G" (isNothing (mkIdent "-93G"))
+        assertBool "not for +0X, no sir" (isNothing (mkIdent "+0X"))
+        assertBool "5 is right out" (isNothing (mkIdent "5"))
     ]
   where
     x ~~> y = parseTest x @?= Right y


### PR DESCRIPTION
I interpret the correct behavior is for identifiers with numeric prefixes to be parse errors; it is this decision about which I am requesting review.  The way this solution works ensures that only identifiers that can be unambiguously parsed can ever become identifiers. 