### PR TITLE
docs: Remove Pandoc dependency

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -1,0 +1,883 @@
+Radicle Reference
+=================
+
+These are the functions that are available in a new radicle chain after
+the prelude has been loaded.
+
+Basics
+------
+
+Basic function used for checking equality, determining the type of a
+value, etc.
+
+``eq?``
+~~~~~~~
+
+Checks if two values are equal.
+
+``not``
+~~~~~~~
+
+True if 'arg' is #f, false otherwise.
+
+``and``
+~~~~~~~
+
+Returns 'arg2' if 'arg1' is not #f, otherwise returns 'arg1'
+
+``or``
+~~~~~~
+
+Returns 'arg1' if 'arg1' is not #f, otherwise returns 'arg2'
+
+``all``
+~~~~~~~
+
+Checks that all the items of a list are truthy.
+
+``some``
+~~~~~~~~
+
+Checks that there is a least one truthy value in a list.
+
+``show``
+~~~~~~~~
+
+Returns a string representing the argument value.
+
+``string-append``
+~~~~~~~~~~~~~~~~~
+
+Concatenates a variable number of string arguments. If one of the
+arguments isn't a string then an exception is thrown.
+
+``string-length``
+~~~~~~~~~~~~~~~~~
+
+Returns the length of a string.
+
+``apply``
+~~~~~~~~~
+
+Calls the first argument (a function) using as arguments the elements of
+the the second argument (a list).
+
+``type``
+~~~~~~~~
+
+Returns a keyword representing the type of the argument; one of:
+``:atom``, ``:keyword``, ``:string``, ``:number``, ``:boolean``,
+``:list``, ``:vector``, ``:function``, ``:dict``, ``:ref``,
+``:function``.
+
+``atom?``
+~~~~~~~~~
+
+Checks if the argument is a atom.
+
+``boolean?``
+~~~~~~~~~~~~
+
+Checks if the argument is a boolean.
+
+``string?``
+~~~~~~~~~~~
+
+Checks if the argument is a string.
+
+``number?``
+~~~~~~~~~~~
+
+Checks if the argument is a number.
+
+``keyword?``
+~~~~~~~~~~~~
+
+Checks if the argument is a keyword.
+
+``list?``
+~~~~~~~~~
+
+Checks if the argument is a list.
+
+``dict?``
+~~~~~~~~~
+
+Checks if the argument is a dict.
+
+``read``
+~~~~~~~~
+
+Parses a string into a radicle value. Does not evaluate the value.
+
+``read-many``
+~~~~~~~~~~~~~
+
+Parses a string into a vector of radicle values. Does not evaluate the
+values.
+
+``throw``
+~~~~~~~~~
+
+Throws an exception. The first argument should be an atom used as a
+label for the exception, the second can be any value.
+
+``Y``
+~~~~~
+
+A combinator used to create recursive functions of one variable.
+
+``Y2``
+~~~~~~
+
+A combinator used to create recursive functions of two variables.
+
+``to-json``
+~~~~~~~~~~~
+
+Returns a JSON formatted string representing the input value.
+
+``uuid?``
+~~~~~~~~~
+
+Checks if a string has the format of a UUID.
+
+``make-counter``
+~~~~~~~~~~~~~~~~
+
+Creates a stateful counter. Returns a dict with two keys: the function
+at ``:next-will-be`` will return the next number (without incrementing
+it), while the function at ``:next`` increments the number and returns
+it.
+
+``public-key?``
+~~~~~~~~~~~~~~~
+
+Checks if a value represents a valid public key.
+
+Numerical functions
+-------------------
+
+Operations on numbers.
+
+``+``
+~~~~~
+
+Adds two numbers together.
+
+``*``
+~~~~~
+
+Multiplies two numbers together.
+
+``-``
+~~~~~
+
+Substracts one number from another.
+
+``<``
+~~~~~
+
+Checks if a number is strictly less than another.
+
+``>``
+~~~~~
+
+Checks if a number is strictly greater than another.
+
+``integral?``
+~~~~~~~~~~~~~
+
+Checks if a number is an integer.
+
+Lists
+-----
+
+Functions for manipulating lists.
+
+``list``
+~~~~~~~~
+
+Turns the arguments into a list.
+
+``nil``
+~~~~~~~
+
+The empty list.
+
+``head``
+~~~~~~~~
+
+Retrieves the first element of a sequence if it exists. Otherwise throws
+an exception.
+
+``tail``
+~~~~~~~~
+
+Given a non-empty sequence, returns the sequence of all the elements but
+the first. If the sequence is empty, throws an exception.
+
+``empty?``
+~~~~~~~~~~
+
+True if 'seq' is empty, false otherwise.
+
+``cons``
+~~~~~~~~
+
+Adds an element to the front of a list.
+
+``reverse``
+~~~~~~~~~~~
+
+Returns the reversed 'list'.
+
+``length``
+~~~~~~~~~~
+
+Returns the length of 'list'.
+
+``concat``
+~~~~~~~~~~
+
+Concatenates 'list1' and 'list2'.
+
+``filter``
+~~~~~~~~~~
+
+Returns 'list' with only the elements that satisfy 'filter-cond'.
+
+``range``
+~~~~~~~~~
+
+Returns a list with all integers from 'start' to 'end', inclusive.
+
+``list-with-head``
+~~~~~~~~~~~~~~~~~~
+
+Given a value ``x``, and two functions ``f`` and ``g``, checks if ``x``
+is a list with a head. If so applies ``f`` to the head, otherwise calls
+``g`` with no args.
+
+Vectors
+-------
+
+Functions for manipulating vectors.
+
+``<>``
+~~~~~~
+
+Concatenates two vectors.
+
+``add-left``
+~~~~~~~~~~~~
+
+Adds an element to the left side of a vector.
+
+``add-right``
+~~~~~~~~~~~~~
+
+Adds an element to the right side of a vector.
+
+Sequences
+---------
+
+Functions for manipulating boths lists and vectors.
+
+``nth``
+~~~~~~~
+
+Given an integral number ``n`` and ``xs``, returns the ``n``\ th element
+(zero indexed) of ``xs`` when ``xs`` is a list or a vector. If ``xs``
+does not have an ``n``-th element, or if it is not a list or vector,
+then an exception is thrown.
+
+``foldl``
+~~~~~~~~~
+
+Given a function ``f``, an initial value ``i`` and a sequence (list or
+vector) ``xs``, reduces ``xs`` to a single value by starting with ``i``
+and repetitively combining values with ``f``, using elements of ``xs``
+from left to right.
+
+``foldr``
+~~~~~~~~~
+
+Given a function ``f``, an initial value ``i`` and a sequence (list or
+vector) ``xs``, reduces ``xs`` to a single value by starting with ``i``
+and repetitively combining values with ``f``, using elements of ``xs``
+from right to left.
+
+``map``
+~~~~~~~
+
+Given a function ``f`` and a sequence (list or vector) ``xs``, returns a
+sequence of the same size and type as ``xs`` but with ``f`` applied to
+all the elements.
+
+``seq``
+~~~~~~~
+
+Given a structure ``s``, returns a sequence. Lists and vectors are
+returned without modification while for dicts a vector of
+key-value-pairs is returned: these are vectors of length 2 whose first
+item is a key and whose second item is the associated value.
+
+``take``
+~~~~~~~~
+
+Returns the first ``n`` items of a sequence, unless the sequence is too
+short, in which case an exception is thrown.
+
+``drop``
+~~~~~~~~
+
+Returns all but the first ``n`` items of a sequence, unless the sequence
+is empty, in which case an exception is thrown.
+
+Dicts
+-----
+
+Functions for manipulating dicts.
+
+``dict``
+~~~~~~~~
+
+Given an even number of arguments, creates a dict where the ``2i``-th
+argument is the key for the ``2i+1``\ th argument.
+
+``lookup``
+~~~~~~~~~~
+
+Given a value ``k`` (the 'key') and a dict ``d``, returns the value
+associated with ``k`` in ``d``. If the key does not exist in ``d`` then
+``()`` is returned instead. If ``d`` is not a dict then an exception is
+thrown.
+
+``insert``
+~~~~~~~~~~
+
+Given ``k``, ``v`` and a dict ``d``, returns a dict with the same
+associations as ``d`` but with ``k`` associated to ``d``. If ``d`` isn't
+a dict then an exception is thrown.
+
+``delete``
+~~~~~~~~~~
+
+Given ``k`` and a dict ``d``, returns a dict with the same associations
+as ``d`` but without the key ``k``. If ``d`` isn't a dict then an
+exception is thrown.
+
+``dict-from-list``
+~~~~~~~~~~~~~~~~~~
+
+Creates a dictionary from a list of key-value pairs.
+
+``keys``
+~~~~~~~~
+
+Given a ``dict``, returns a vector of its keys.
+
+``values``
+~~~~~~~~~~
+
+Given a ``dict``, returns a vector of its values.
+
+``rekey``
+~~~~~~~~~
+
+Change the key from 'old-key' to 'new-key' in 'dict'. If 'new-key'
+already exists, it is overwritten.
+
+``map-values``
+~~~~~~~~~~~~~~
+
+Given a function ``f`` and a dict ``d``, returns a dict with the same
+keys as ``d`` but ``f`` applied to all the associated values.
+
+``modify-map``
+~~~~~~~~~~~~~~
+
+Given a key, a function and a dict, applies the function to the value
+associated to that key.
+
+Structures
+----------
+
+Functions for manipulating lists, vectors and dicts.
+
+``member?``
+~~~~~~~~~~~
+
+Given ``v`` and structure ``s``, checks if ``x`` exists in ``s``. The
+structure ``s`` may be a list, vector or dict. If it is a list or a
+vector, it checks if ``v`` is one of the items. If ``s`` is a dict, it
+checks if ``v`` is one of the keys.
+
+Refs
+----
+
+Functions for creating, querying and modifying refs.
+
+``ref``
+~~~~~~~
+
+Creates a ref with the argument as the initial value.
+
+``read-ref``
+~~~~~~~~~~~~
+
+Returns the current value of a ref.
+
+``write-ref``
+~~~~~~~~~~~~~
+
+Given a reference ``r`` and a value ``v``, updates the value stored in
+``r`` to be ``v`` and returns ``v``.
+
+``modify-ref``
+~~~~~~~~~~~~~~
+
+Modify 'ref' by applying the provided function. Returns the new value.
+
+Evaluation functions
+--------------------
+
+Utilities for creating and extending evaluation functions.
+
+``base-eval``
+~~~~~~~~~~~~~
+
+The default evaluation function. Expects an expression and a radicle
+state. Return a list of length 2 consisting of the result of the
+evaluation and the new state.
+
+``eval``
+~~~~~~~~
+
+An eval in which one can use ``(:enter-chain url)`` to make the eval
+behave as that of a remote chain, and ``:send`` to send all enqueued
+expressions.
+
+``updatable-eval``
+~~~~~~~~~~~~~~~~~~
+
+Given an evaluation function ``f``, returns a new one which augments
+``f`` with a new command ``(update expr)`` which evaluates arbitrary
+expression using ``base-eval``.
+
+Documentation and testing
+-------------------------
+
+Functions for creating and querying documentation of variables in scope,
+and testing functions.
+
+``doc``
+~~~~~~~
+
+Returns the documentation string for a variable. To print it instead,
+use ``doc!``.
+
+``doc!``
+~~~~~~~~
+
+Prints the documentation attached to a value and returns ``()``. To
+retrieve the docstring as a value use ``doc`` instead.
+
+``apropos!``
+~~~~~~~~~~~~
+
+Prints documentation for all documented variables in scope.
+
+``document``
+~~~~~~~~~~~~
+
+Used to add documentation to variables.
+
+``is-test-env``
+~~~~~~~~~~~~~~~
+
+True iff file is being run as part of the Haskell suite
+
+Environment functions
+---------------------
+
+Utilities for modifying the current environment.
+
+``pure-env``
+~~~~~~~~~~~~
+
+Returns a pure initial radicle state. This is the state of a radicle
+chain before it has processed any inputs.
+
+``get-current-env``
+~~~~~~~~~~~~~~~~~~~
+
+Returns the current radicle state.
+
+``set-current-env``
+~~~~~~~~~~~~~~~~~~~
+
+Replaces the radicle state with the one provided.
+
+``set-env!``
+~~~~~~~~~~~~
+
+Given an atom ``x`` and a value ``v``, sets the value associated to
+``x`` in the current environemtn to be ``v``. Doesn't evaluate ``v``.
+
+Input/Output
+------------
+
+Effectful functions. These functions are not available in 'pure' chains,
+but are available in the local REPL.
+
+``print!``
+~~~~~~~~~~
+
+Pretty-prints a value.
+
+``get-line!``
+~~~~~~~~~~~~~
+
+Reads a single line of input and returns it as a string.
+
+``load!``
+~~~~~~~~~
+
+Evaluates the contents of a file. Each seperate radicle expression is
+``eval``\ uated according to the current definition of ``eval``.
+
+``read-file!``
+~~~~~~~~~~~~~~
+
+Reads the contents of a file and returns it as a string.
+
+``read-code!``
+~~~~~~~~~~~~~~
+
+Read code (as data) from a file. Returns a vector of expressions
+
+``send-code!``
+~~~~~~~~~~~~~~
+
+Send code from a file to a remote chain.
+
+``send-prelude!``
+~~~~~~~~~~~~~~~~~
+
+Send the pure prelude to a chain.
+
+``subscribe-to!``
+~~~~~~~~~~~~~~~~~
+
+Expects a dict ``s`` (representing a subscription) and a function ``f``.
+The dict ``s`` should have a function ``getter`` at the key ``:getter``.
+This function is called repeatedly (with no arguments), its result is
+then evaluated and passed to ``f``.
+
+``uuid!``
+~~~~~~~~~
+
+Generates a random UUID.
+
+``read-line!``
+~~~~~~~~~~~~~~
+
+Read a single line of input and interpret it as radicle data.
+
+``exit!``
+~~~~~~~~~
+
+Exit the interpreter immediately.
+
+Lenses
+------
+
+Functional references into radicle values.
+
+``@``
+~~~~~
+
+Returns a lens targetting keys of dicts.
+
+``@nth``
+~~~~~~~~
+
+Lenses into the nth element of a vector
+
+``make-lens``
+~~~~~~~~~~~~~
+
+Makes a lens out of a getter and a setter.
+
+``view``
+~~~~~~~~
+
+View a value through a lens.
+
+``view-ref``
+~~~~~~~~~~~~
+
+Like 'view', but for refs.
+
+``set``
+~~~~~~~
+
+Set a value though a lens.
+
+``set-ref``
+~~~~~~~~~~~
+
+Like 'set', but for refs.
+
+``over``
+~~~~~~~~
+
+Modify a value through a lens.
+
+``over-ref``
+~~~~~~~~~~~~
+
+Like 'over', but for refs.
+
+``id-lens``
+~~~~~~~~~~~
+
+The identity lens.
+
+``..``
+~~~~~~
+
+Compose two lenses.
+
+``...``
+~~~~~~~
+
+Compose multiple lenses.
+
+Validation
+----------
+
+Functions for creating or combining *validators*, which are functions
+which return the input unchanged or throw with an error message. These
+can be used for checking data before accepting it onto a chain.
+
+``validator/=``
+~~~~~~~~~~~~~~~
+
+Given ``x``, returns a validator that checks for equality with ``x``.
+
+``validator/member``
+~~~~~~~~~~~~~~~~~~~~
+
+Given a structure, returns a validator which checks for membership in
+the structure.
+
+``validator/type``
+~~~~~~~~~~~~~~~~~~
+
+Checks that a value has a type. Expects a keyword describing the type,
+as returned by the ``type`` function.
+
+``validator/pred``
+~~~~~~~~~~~~~~~~~~
+
+Given a description and a predicate, returns a validator that checks if
+the predicate is true.
+
+``validator/every``
+~~~~~~~~~~~~~~~~~~~
+
+Given a validator, creates a new validator which checks that all the
+items in a sequence conform to it.
+
+``validator/and``
+~~~~~~~~~~~~~~~~~
+
+Given a sequence of validators ``vs``, returns a new validator which,
+given a value, checks if it conforms to all the validators in ``vs``.
+
+``validator/or``
+~~~~~~~~~~~~~~~~
+
+Given a vector of validators ``vs``, returns a new validator which,
+given a value, checks if it conforms to at least one of the ``vs``.
+
+``validator/key``
+~~~~~~~~~~~~~~~~~
+
+Given a key and a validator, returns a validator which checks for the
+existence of that key and that the associated value conforms to the
+validator.
+
+``validator/keys``
+~~~~~~~~~~~~~~~~~~
+
+Given a dict associating keys to validators, returns a validator which
+checks a dict for the existence of those keys, and that they conform to
+the associated validators.
+
+Cryptography
+------------
+
+Tools for creating and verifying cryptographic signatures, and
+generating private/public key pairs.
+
+``verify-signature``
+~~~~~~~~~~~~~~~~~~~~
+
+Given a public key ``pk``, a signature ``s`` and a message (string)
+``m``, checks that ``s`` is a signature of ``m`` for the public key
+``pk``.
+
+``default-ecc-curve``
+~~~~~~~~~~~~~~~~~~~~~
+
+Returns the default elliptic-curve used for generating cryptographic
+keys.
+
+``gen-key-pair!``
+~~~~~~~~~~~~~~~~~
+
+Given an elliptic curve, generates a cryptographic key-pair. Use
+``default-ecc-curve`` for a default value for the elliptic curve.
+
+``gen-signature!``
+~~~~~~~~~~~~~~~~~~
+
+Given a private key and a message (a string), generates a cryptographic
+signature for the message.
+
+Chain tools
+-----------
+
+These functions can be used to simulate remote chains in the local REPL.
+This is useful for experimenting with inputs or even new evaluation
+functions before sending these to a remote chain.
+
+``new-chain``
+~~~~~~~~~~~~~
+
+Return an empty chain dictionary with the given url.
+
+``eval-in-chain``
+~~~~~~~~~~~~~~~~~
+
+Evaluates 'expr' in the 'chain' and returns a dict with the ':result'
+and the resulting ':chain'.
+
+``enter-remote-chain``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Make the eval behave as that of a remote chain. The second param is the
+env to return to after :quit.
+
+``update-chain``
+~~~~~~~~~~~~~~~~
+
+Takes a chain, and returns a new chain updated with the new expressions
+from the remote chain
+
+``add-quit``
+~~~~~~~~~~~~
+
+Adds a ':quit' command to 'before-quit-eval', which switches to
+'after-quit-state' (and to the eval in that state)
+
+``add-send``
+~~~~~~~~~~~~
+
+Add a :send special form that sends the contents of *input to the
+chain*\ cur-chain
+
+``load-chain``
+~~~~~~~~~~~~~~
+
+Takes a ``url``, and fetches the inputs of a remote chain and return a
+chain dictionary with the chain state.
+
+``pure-prelude-files``
+~~~~~~~~~~~~~~~~~~~~~~
+
+List of files which together define the pure prelude.
+
+``pure-prelude-code``
+~~~~~~~~~~~~~~~~~~~~~
+
+The pure prelude.
+
+``store-exprs``
+~~~~~~~~~~~~~~~
+
+Store each new evaluated expression in '_inputs'
+
+``eval-fn-app``
+~~~~~~~~~~~~~~~
+
+Given a state, a function, an argument and a callback, returns the
+result of evaluating the function call on the arg in the given state,
+while also calling the callback on the result.
+
+``state-machine-eval``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Returns an eval which operates a state machine whose transition function
+may be updated. To update the transition function all voters must agree
+on it.
+
+``state-machine-input``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Handle an input in the morphing state-machine.
+
+``state-machine-new-trans``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Trigger a new vote.
+
+``state-machine-agree``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Vote to agree on a new transition function.
+
+``state-machine-disagree``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Vote to disagree on a new transition function.
+
+``simple-trans``
+~~~~~~~~~~~~~~~~
+
+Given a function ``f``, makes a transition function who's output is also
+the next state.
+
+``update-chain-ref``
+~~~~~~~~~~~~~~~~~~~~
+
+Update a ref containing a chain with the new expressions from the remote
+chain
+
+Issue chain
+-----------
+
+These functions allow creating and interacting with the default issues
+chain.
+
+``create-issues-chain!``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Create a remote issue chain with the given url. Returns a ref with the
+chain.
+
+``list-issues``
+~~~~~~~~~~~~~~~
+
+Given an issues ref ``x``, returns its issues. Does not itself update
+the chain.
+
+``new-issue!``
+~~~~~~~~~~~~~~
+
+Create a new remote issue. Takes a chain ref, a keypair, an issue title
+and an issue body.

--- a/exe/RadicleExe.hs
+++ b/exe/RadicleExe.hs
@@ -17,7 +17,6 @@ import           Servant.Client
 import           System.Console.Haskeline (InputT)
 import           System.Directory (doesFileExist)
 
-import           Radicle.Internal.Doc (md)
 import qualified Radicle.Internal.PrimFns as PrimFns
 
 main :: IO ()
@@ -83,8 +82,8 @@ clientPrimFns mgr = fromList . PrimFns.allDocs $ [sendPrimop, receivePrimop]
   where
     sendPrimop =
       ( "send!"
-      , [md|Given a URL (string) and a value, sends the value `v` to the remote
-           chain located at the URL for evaluation.|]
+      , "Given a URL (string) and a value, sends the value `v` to the remote\
+        \chain located at the URL for evaluation."
       , \case
          [String url, Vec v] -> do
              res <- liftIO $ runClientM' url mgr (submit $ toList v)
@@ -98,8 +97,8 @@ clientPrimFns mgr = fromList . PrimFns.allDocs $ [sendPrimop, receivePrimop]
       )
     receivePrimop =
       ( "receive!"
-      , [md|Given a URL (string) and a integral number `n`, queries the remote chain
-           for the last `n` inputs that have been evaluated.|]
+      , "Given a URL (string) and a integral number `n`, queries the remote chain\
+        \for the last `n` inputs that have been evaluated."
       , \case
           [String url, Number n] -> do
               case floatingOrInteger n of

--- a/exe/RadicleExe.hs
+++ b/exe/RadicleExe.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE QuasiQuotes #-}
-
 module RadicleExe (main) where
 
 import           API

--- a/exe/RadicleExe.hs
+++ b/exe/RadicleExe.hs
@@ -83,7 +83,7 @@ clientPrimFns mgr = fromList . PrimFns.allDocs $ [sendPrimop, receivePrimop]
     sendPrimop =
       ( "send!"
       , "Given a URL (string) and a value, sends the value `v` to the remote\
-        \chain located at the URL for evaluation."
+        \ chain located at the URL for evaluation."
       , \case
          [String url, Vec v] -> do
              res <- liftIO $ runClientM' url mgr (submit $ toList v)
@@ -98,7 +98,7 @@ clientPrimFns mgr = fromList . PrimFns.allDocs $ [sendPrimop, receivePrimop]
     receivePrimop =
       ( "receive!"
       , "Given a URL (string) and a integral number `n`, queries the remote chain\
-        \for the last `n` inputs that have been evaluated."
+        \ for the last `n` inputs that have been evaluated."
       , \case
           [String url, Number n] -> do
               case floatingOrInteger n of

--- a/exe/ReferenceDoc.hs
+++ b/exe/ReferenceDoc.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE QuasiQuotes #-}
 -- | This executable generates the radicle reference docs. This is a markdown
 -- document which contains documentation for all the primitive functions and all
 -- the functions defined in the prelude.

--- a/exe/ReferenceDoc.hs
+++ b/exe/ReferenceDoc.hs
@@ -62,14 +62,14 @@ main = do
             "Functional references into radicle values."
       , sec "Validation" validation
             "Functions for creating or combining *validators*, which are functions which return the\
-            \input unchanged or throw with an error message. These can be used for checking data before\
-            \accepting it onto a chain."
+            \ input unchanged or throw with an error message. These can be used for checking data before\
+            \ accepting it onto a chain."
       , sec "Cryptography" crypto
             "Tools for creating and verifying cryptographic signatures, and generating private/public key pairs."
       , sec "Chain tools" chainTools
             "These functions can be used to simulate remote chains in the local REPL.\
-            \This is useful for experimenting with inputs or even new evaluation functions\
-            \before sending these to a remote chain."
+            \ This is useful for experimenting with inputs or even new evaluation functions\
+            \ before sending these to a remote chain."
       , sec "Issue chain" issueChain
             "These functions allow creating and interacting with the default issues chain."
       ]
@@ -77,7 +77,7 @@ main = do
     basics =
       [ "eq?", "not", "and", "or", "all", "some", "show", "string-append", "string-length"
       , "apply", "type", "atom?", "boolean?", "string?", "number?", "keyword?", "list?"
-      , "dict?", "read", "read-many", "throw", "Y", "Y2", "to-json", "uuid?", "make-counter", "markdown?"
+      , "dict?", "read", "read-many", "throw", "Y", "Y2", "to-json", "uuid?", "make-counter"
       , "public-key?" ]
     maths = ["+", "*", "-", "<", ">", "integral?"]
     evalFns = ["base-eval", "eval", "updatable-eval"]

--- a/exe/ReferenceDoc.hs
+++ b/exe/ReferenceDoc.hs
@@ -12,7 +12,6 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified GHC.Exts as GhcExts
 import           Radicle
-import           Radicle.Internal.Doc (md)
 import           System.Console.Haskeline (defaultSettings, runInputT)
 import           Text.Pandoc
 
@@ -62,17 +61,17 @@ main = do
       , sec "Lenses" lens
             "Functional references into radicle values."
       , sec "Validation" validation
-            [md|Functions for creating or combining *validators*, which are functions which return the
-               input unchanged or throw with an error message. These can be used for checking data before
-               accepting it onto a chain.|]
+            "Functions for creating or combining *validators*, which are functions which return the\
+            \input unchanged or throw with an error message. These can be used for checking data before\
+            \accepting it onto a chain."
       , sec "Cryptography" crypto
             "Tools for creating and verifying cryptographic signatures, and generating private/public key pairs."
       , sec "Chain tools" chainTools
-            [md|These functions can be used to simulate remote chains in the local REPL.
-               This is useful for experimenting with inputs or even new evaluation functions
-               before sending these to a remote chain.|]
+            "These functions can be used to simulate remote chains in the local REPL.\
+            \This is useful for experimenting with inputs or even new evaluation functions\
+            \before sending these to a remote chain."
       , sec "Issue chain" issueChain
-            [md|These functions allow creating and interacting with the default issues chain.|]
+            "These functions allow creating and interacting with the default issues chain."
       ]
 
     basics =

--- a/package.yaml
+++ b/package.yaml
@@ -22,7 +22,6 @@ dependencies:
 - haskeline
 - megaparsec
 - mtl
-- pandoc
 - pointed
 - prettyprinter
 - prettyprinter-ansi-terminal

--- a/src/Radicle/Internal/Doc.hs
+++ b/src/Radicle/Internal/Doc.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE TemplateHaskell       #-}
 
 module Radicle.Internal.Doc where
 

--- a/src/Radicle/Internal/Doc.hs
+++ b/src/Radicle/Internal/Doc.hs
@@ -8,8 +8,6 @@ import           Protolude hiding (Any)
 import           Codec.Serialise (Serialise(..))
 import           Data.Copointed (Copointed(..))
 import qualified Data.Default as Default
-import           Language.Haskell.TH.Quote
-import           Text.Pandoc
 
 data Docd a = Docd (Maybe Text) a
   deriving (Show, Read, Functor, Foldable, Traversable, Generic)
@@ -31,21 +29,3 @@ instance Ord a => Ord (Docd a) where
 noDocs :: [(a, c)] -> [(a, Maybe b, c)]
 noDocs = fmap $ \(x,y) -> (x, Nothing, y)
 
--- | A quasiquoter that checks if a string is valid pandoc-markdown, then
--- returns the markdown with better formatting.
-md :: QuasiQuoter
-md = QuasiQuoter
-    { quoteExp = \s -> [| case cleanupPandocMd s of
-        Left e   -> panic $ "Not valid pandoc-markdown: " <> show e
-        Right s' -> s' |]
-    , quoteType = err
-    , quotePat = err
-    , quoteDec = err
-    }
-  where
-    err = panic "pan only works for expressions"
-
-cleanupPandocMd :: Text -> Either PandocError Text
-cleanupPandocMd s = runPure $ do
-  p <- readMarkdown Default.def s
-  writeMarkdown Default.def p

--- a/src/Radicle/Internal/Doc.hs
+++ b/src/Radicle/Internal/Doc.hs
@@ -7,7 +7,6 @@ import           Protolude hiding (Any)
 
 import           Codec.Serialise (Serialise(..))
 import           Data.Copointed (Copointed(..))
-import qualified Data.Default as Default
 
 data Docd a = Docd (Maybe Text) a
   deriving (Show, Read, Functor, Foldable, Traversable, Generic)

--- a/src/Radicle/Internal/Effects.hs
+++ b/src/Radicle/Internal/Effects.hs
@@ -23,7 +23,6 @@ import           System.Console.Haskeline
 
 import           Radicle.Internal.Core
 import           Radicle.Internal.Crypto
-import           Radicle.Internal.Doc (md)
 import           Radicle.Internal.Effects.Capabilities
 import           Radicle.Internal.Interpret
 import           Radicle.Internal.Pretty
@@ -79,7 +78,7 @@ replBindings = addPrimFns replPrimFns pureEnv
 replPrimFns :: ReplM m => PrimFns m
 replPrimFns = fromList $ allDocs $
     [ ("print!"
-      , [md|Pretty-prints a value.|]
+      , "Pretty-prints a value."
       , \case
         [x] -> do
             putStrS (renderPrettyDef x)
@@ -87,8 +86,8 @@ replPrimFns = fromList $ allDocs $
         xs  -> throwErrorHere $ WrongNumberOfArgs "print!" 1 (length xs))
 
     , ( "doc!"
-      , [md|Prints the documentation attached to a value and returns `()`. To retreive
-           the docstring as a value use `doc` instead.|]
+      , "Prints the documentation attached to a value and returns `()`. To retreive\
+        \the docstring as a value use `doc` instead."
       , oneArg "doc!" $ \case
           Atom i -> do
             d <- lookupAtomDoc i
@@ -98,7 +97,7 @@ replPrimFns = fromList $ allDocs $
       )
 
     , ( "apropos!"
-      , [md|Prints documentation for all documented variables in scope.|]
+      , "Prints documentation for all documented variables in scope."
       , \case
           [] -> do
             env <- gets bindingsEnv
@@ -109,8 +108,8 @@ replPrimFns = fromList $ allDocs $
       )
 
     , ( "set-env!"
-      , [md|Given an atom `x` and a value `v`, sets the value associated to `x` in
-           the current environemtn to be `v`. Doesn't evaluate `v`.|]
+      , "Given an atom `x` and a value `v`, sets the value associated to `x` in\
+        \the current environemtn to be `v`. Doesn't evaluate `v`."
       , \case
         [Atom x, v] -> do
             defineAtom x Nothing v
@@ -119,16 +118,16 @@ replPrimFns = fromList $ allDocs $
         xs  -> throwErrorHere $ WrongNumberOfArgs "set-env!" 2 (length xs))
 
     , ( "get-line!"
-      , [md|Reads a single line of input and returns it as a string.|]
+      , "Reads a single line of input and returns it as a string."
       , \case
           [] -> maybe nil toRad <$> getLineS
           xs -> throwErrorHere $ WrongNumberOfArgs "get-line!" 0 (length xs)
       )
 
     , ("subscribe-to!"
-      , [md|Expects a dict `s` (representing a subscription) and a function `f`. The dict
-           `s` should have a function `getter` at the key `:getter`. This function is called
-           repeatedly (with no arguments), its result is then evaluated and passed to `f`.|]
+      , "Expects a dict `s` (representing a subscription) and a function `f`. The dict\
+        \`s` should have a function `getter` at the key `:getter`. This function is called\
+        \repeatedly (with no arguments), its result is then evaluated and passed to `f`."
       , \case
         [x, v] -> do
             e <- gets bindingsEnv
@@ -163,7 +162,7 @@ replPrimFns = fromList $ allDocs $
                 _  -> throwErrorHere $ TypeError "subscribe-to!: Expected dict"
         xs  -> throwErrorHere $ WrongNumberOfArgs "subscribe-to!" 2 (length xs))
     , ( "read-file!"
-      , [md|Reads the contents of a file and returns it as a string.|]
+      , "Reads the contents of a file and returns it as a string."
       , oneArg "read-file" $ \case
           String filename -> readFileS filename >>= \case
               Left err -> throwErrorHere . OtherError $ "Error reading file: " <> err
@@ -171,8 +170,8 @@ replPrimFns = fromList $ allDocs $
           _ -> throwErrorHere $ TypeError "read-file: expects a string"
       )
     , ( "load!"
-      , [md|Evaluates the contents of a file. Each seperate radicle expression is
-           `eval`uated according to the current definition of `eval`.|]
+      , "Evaluates the contents of a file. Each seperate radicle expression is\
+        \`eval`uated according to the current definition of `eval`."
       , oneArg "load!" $ \case
           String filename -> readFileS filename >>= \case
               Left err -> throwErrorHere . OtherError $ "Error reading file: " <> err
@@ -180,8 +179,8 @@ replPrimFns = fromList $ allDocs $
           _ -> throwErrorHere $ TypeError "load: expects a string"
       )
     , ( "gen-key-pair!"
-      , [md|Given an elliptic curve, generates a cryptographic key-pair. Use
-           `default-ecc-curve` for a default value for the elliptic curve.|]
+      , "Given an elliptic curve, generates a cryptographic key-pair. Use\
+        \`default-ecc-curve` for a default value for the elliptic curve."
       , oneArg "gen-key-pair!" $ \case
           curvev -> do
             curve <- hoistEither . first (toLangError . OtherError) $ fromRad curvev
@@ -194,8 +193,8 @@ replPrimFns = fromList $ allDocs $
               ]
       )
     , ( "gen-signature!"
-      , [md|Given a private key and a message (a string), generates a cryptographic
-           signature for the message.|]
+      , "Given a private key and a message (a string), generates a cryptographic\
+        \signature for the message."
       , \case
           [skv, String msg] -> do
             sk <- hoistEither . first (toLangError . OtherError) $ fromRad skv
@@ -203,13 +202,13 @@ replPrimFns = fromList $ allDocs $
           _ -> throwErrorHere $ TypeError "gen-signature!: expects a string."
       )
     , ( "uuid!"
-      , [md|Generates a random UUID.|]
+      , "Generates a random UUID."
       , \case
           [] -> String <$> UUID.uuid
           xs -> throwErrorHere $ WrongNumberOfArgs "uuid!" 0 (length xs)
       )
     , ( "exit!"
-      , [md|Exit the interpreter immediately.|]
+      , "Exit the interpreter immediately."
       , \case
           [] -> throwErrorHere Exit
           xs -> throwErrorHere $ WrongNumberOfArgs "exit!" 0 (length xs)

--- a/src/Radicle/Internal/Effects.hs
+++ b/src/Radicle/Internal/Effects.hs
@@ -1,5 +1,4 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# LANGUAGE QuasiQuotes #-}
 
 module Radicle.Internal.Effects where
 

--- a/src/Radicle/Internal/Effects.hs
+++ b/src/Radicle/Internal/Effects.hs
@@ -86,8 +86,8 @@ replPrimFns = fromList $ allDocs $
         xs  -> throwErrorHere $ WrongNumberOfArgs "print!" 1 (length xs))
 
     , ( "doc!"
-      , "Prints the documentation attached to a value and returns `()`. To retreive\
-        \the docstring as a value use `doc` instead."
+      , "Prints the documentation attached to a value and returns `()`. To retrieve\
+        \ the docstring as a value use `doc` instead."
       , oneArg "doc!" $ \case
           Atom i -> do
             d <- lookupAtomDoc i
@@ -109,7 +109,7 @@ replPrimFns = fromList $ allDocs $
 
     , ( "set-env!"
       , "Given an atom `x` and a value `v`, sets the value associated to `x` in\
-        \the current environemtn to be `v`. Doesn't evaluate `v`."
+        \ the current environemtn to be `v`. Doesn't evaluate `v`."
       , \case
         [Atom x, v] -> do
             defineAtom x Nothing v
@@ -126,8 +126,8 @@ replPrimFns = fromList $ allDocs $
 
     , ("subscribe-to!"
       , "Expects a dict `s` (representing a subscription) and a function `f`. The dict\
-        \`s` should have a function `getter` at the key `:getter`. This function is called\
-        \repeatedly (with no arguments), its result is then evaluated and passed to `f`."
+        \ `s` should have a function `getter` at the key `:getter`. This function is called\
+        \ repeatedly (with no arguments), its result is then evaluated and passed to `f`."
       , \case
         [x, v] -> do
             e <- gets bindingsEnv
@@ -171,7 +171,7 @@ replPrimFns = fromList $ allDocs $
       )
     , ( "load!"
       , "Evaluates the contents of a file. Each seperate radicle expression is\
-        \`eval`uated according to the current definition of `eval`."
+        \ `eval`uated according to the current definition of `eval`."
       , oneArg "load!" $ \case
           String filename -> readFileS filename >>= \case
               Left err -> throwErrorHere . OtherError $ "Error reading file: " <> err
@@ -180,7 +180,7 @@ replPrimFns = fromList $ allDocs $
       )
     , ( "gen-key-pair!"
       , "Given an elliptic curve, generates a cryptographic key-pair. Use\
-        \`default-ecc-curve` for a default value for the elliptic curve."
+        \ `default-ecc-curve` for a default value for the elliptic curve."
       , oneArg "gen-key-pair!" $ \case
           curvev -> do
             curve <- hoistEither . first (toLangError . OtherError) $ fromRad curvev
@@ -194,7 +194,7 @@ replPrimFns = fromList $ allDocs $
       )
     , ( "gen-signature!"
       , "Given a private key and a message (a string), generates a cryptographic\
-        \signature for the message."
+        \ signature for the message."
       , \case
           [skv, String msg] -> do
             sk <- hoistEither . first (toLangError . OtherError) $ fromRad skv

--- a/src/Radicle/Internal/PrimFns.hs
+++ b/src/Radicle/Internal/PrimFns.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE QuasiQuotes #-}
-
 module Radicle.Internal.PrimFns where
 
 import           Protolude hiding (TypeError)

--- a/src/Radicle/Internal/PrimFns.hs
+++ b/src/Radicle/Internal/PrimFns.hs
@@ -54,8 +54,8 @@ purePrimFns :: forall m. (Monad m) => PrimFns m
 purePrimFns = fromList $ allDocs $
     [ ( "base-eval"
       , "The default evaluation function. Expects an expression and a radicle\
-        \state. Return a list of length 2 consisting of the result of the\
-        \evaluation and the new state."
+        \ state. Return a list of length 2 consisting of the result of the\
+        \ evaluation and the new state."
       , \case
           [expr, st] -> case (fromRad st :: Either Text (Bindings ())) of
               Left e -> throwErrorHere $ OtherError e
@@ -69,14 +69,14 @@ purePrimFns = fromList $ allDocs $
       )
     , ( "pure-env"
       , "Returns a pure initial radicle state. This is the state of a radicle\
-        \chain before it has processed any inputs."
+        \ chain before it has processed any inputs."
       , \case
           [] -> pure $ toRad (pureEnv :: Bindings (PrimFns m))
           xs -> throwErrorHere $ WrongNumberOfArgs "pure-env" 0 (length xs)
       )
     , ("apply"
       , "Calls the first argument (a function) using as arguments the\
-        \elements of the the second argument (a list)."
+        \ elements of the the second argument (a list)."
       , \case
           [fn, List args] -> callFn fn args
           [_, _]          -> throwErrorHere $ TypeError "apply: expecting list as second arg"
@@ -114,12 +114,12 @@ purePrimFns = fromList $ allDocs $
       , pure . List)
     , ("dict"
       , "Given an even number of arguments, creates a dict where the `2i`-th argument\
-        \is the key for the `2i+1`th argument."
+        \ is the key for the `2i+1`th argument."
       , (Dict . foldr (uncurry Map.insert) mempty <$>)
                         . evenArgs "dict")
     , ("throw"
       , "Throws an exception. The first argument should be an atom used as a label for\
-        \the exception, the second can be any value."
+        \ the exception, the second can be any value."
       , \case
           [Atom label, exc] -> throwErrorHere $ ThrownError label exc
           [_, _]            -> throwErrorHere $ TypeError "throw: first argument must be atom"
@@ -159,7 +159,7 @@ purePrimFns = fromList $ allDocs $
           xs           -> throwErrorHere $ WrongNumberOfArgs "cons" 2 (length xs))
     , ("head"
       , "Retrieves the first element of a sequence if it exists. Otherwise throws an\
-        \exception."
+        \ exception."
       , oneArg "head" $ \case
           List (x:_)        -> pure x
           List []           -> throwErrorHere $ OtherError "head: empty list"
@@ -168,7 +168,7 @@ purePrimFns = fromList $ allDocs $
           _                 -> throwErrorHere $ TypeError "head: expects sequence argument")
     , ("tail"
       , "Given a non-empty sequence, returns the sequence of all the elements but the\
-        \first. If the sequence is empty, throws an exception."
+        \ first. If the sequence is empty, throws an exception."
       , oneArg "tail" $ \case
           List (_:xs)        -> pure $ List xs
           List []            -> throwErrorHere $ OtherError "tail: empty list"
@@ -179,7 +179,7 @@ purePrimFns = fromList $ allDocs $
     -- Lists and Vecs
     , ( "drop"
       , "Returns all but the first `n` items of a sequence, unless the sequence is empty,\
-        \in which case an exception is thrown."
+        \ in which case an exception is thrown."
       , twoArg "drop" $ \case
           (Number n, vs) -> case floatingOrInteger n of
             Left (_ :: Double) -> throwErrorHere $ OtherError "drop: first argument must be an integer"
@@ -191,7 +191,7 @@ purePrimFns = fromList $ allDocs $
       )
     , ( "take"
       , "Returns the first `n` items of a sequence, unless the sequence is too short,\
-        \in which case an exception is thrown."
+        \ in which case an exception is thrown."
       , twoArg "take" $ \case
           (Number n, vs) -> case floatingOrInteger n of
             Left (_ :: Double) -> throwErrorHere $ OtherError "take: first argument must be an integer"
@@ -203,9 +203,9 @@ purePrimFns = fromList $ allDocs $
       )
     , ( "nth"
       , "Given an integral number `n` and `xs`, returns the `n`th element\
-        \(zero indexed) of `xs` when `xs` is a list or a vector. If `xs`\
-        \does not have an `n`-th element, or if it is not a list or vector, then\
-        \an exception is thrown."
+        \ (zero indexed) of `xs` when `xs` is a list or a vector. If `xs`\
+        \ does not have an `n`-th element, or if it is not a list or vector, then\
+        \ an exception is thrown."
       , \case
           [Number n, vs] -> case floatingOrInteger n of
             Left (_ :: Double) -> throwErrorHere $ OtherError "nth: first argument was not an integer"
@@ -220,8 +220,8 @@ purePrimFns = fromList $ allDocs $
 
     , ("lookup"
       , "Given a value `k` (the 'key') and a dict `d`, returns the value associated\
-        \with `k` in `d`. If the key does not exist in `d` then `()` is returned\
-        \instead. If `d` is not a dict then an exception is thrown."
+        \ with `k` in `d`. If the key does not exist in `d` then `()` is returned\
+        \ instead. If `d` is not a dict then an exception is thrown."
       , \case
           [a, Dict m] -> pure $ case Map.lookup a m of
               Just v  -> v
@@ -232,7 +232,7 @@ purePrimFns = fromList $ allDocs $
           xs -> throwErrorHere $ WrongNumberOfArgs "lookup" 2 (length xs))
     , ( "map-values"
       , "Given a function `f` and a dict `d`, returns a dict with the same keys as `d`\
-        \but `f` applied to all the associated values."
+        \ but `f` applied to all the associated values."
       , twoArg "map-values" $ \case
           (f, Dict m) -> do
             let kvs = Map.toList m
@@ -248,7 +248,7 @@ purePrimFns = fromList $ allDocs $
       )
     , ( "string-append"
       , "Concatenates a variable number of string arguments. If one of the arguments\
-        \isn't a string then an exception is thrown."
+        \ isn't a string then an exception is thrown."
       , \args ->
           let fromStr (String s) = Just s
               fromStr _          = Nothing
@@ -259,8 +259,8 @@ purePrimFns = fromList $ allDocs $
       )
     , ( "insert"
       , "Given `k`, `v` and a dict `d`, returns a dict with the same associations\
-        \as `d` but with `k` associated to `d`. If `d` isn't a dict then an exception\
-        \is thrown."
+        \ as `d` but with `k` associated to `d`. If `d` isn't a dict then an exception\
+        \ is thrown."
       , \case
           [k, v, Dict m] -> pure . Dict $ Map.insert k v m
           [_, _, _]                -> throwErrorHere
@@ -269,7 +269,7 @@ purePrimFns = fromList $ allDocs $
           xs -> throwErrorHere $ WrongNumberOfArgs "insert" 3 (length xs))
     , ( "delete"
       , "Given `k` and a dict `d`, returns a dict with the same associations as `d` but\
-        \without the key `k`. If `d` isn't a dict then an exception is thrown."
+        \ without the key `k`. If `d` isn't a dict then an exception is thrown."
       , twoArg "delete" $ \case
           (k, Dict m) -> pure . Dict $ Map.delete k m
           _ -> throwErrorHere $ TypeError "delete: second argument must be a dict"
@@ -307,8 +307,8 @@ purePrimFns = fromList $ allDocs $
       )
     , ( "foldl"
       , "Given a function `f`, an initial value `i` and a sequence (list or vector)\
-        \`xs`, reduces `xs` to a single value by starting with `i` and repetitively\
-        \combining values with `f`, using elements of `xs` from left to right."
+        \ `xs`, reduces `xs` to a single value by starting with `i` and repetitively\
+        \ combining values with `f`, using elements of `xs` from left to right."
       , \case
           [fn, init', v] -> do
             ls :: [Value] <- fromRadOtherErr v
@@ -316,8 +316,8 @@ purePrimFns = fromList $ allDocs $
           xs                   -> throwErrorHere $ WrongNumberOfArgs "foldl" 3 (length xs))
     , ( "foldr"
       , "Given a function `f`, an initial value `i` and a sequence (list or vector)\
-        \`xs`, reduces `xs` to a single value by starting with `i` and repetitively\
-        \combining values with `f`, using elements of `xs` from right to left."
+        \ `xs`, reduces `xs` to a single value by starting with `i` and repetitively\
+        \ combining values with `f`, using elements of `xs` from right to left."
       , \case
           [fn, init', v] -> do
             ls :: [Value] <- fromRadOtherErr v
@@ -325,7 +325,7 @@ purePrimFns = fromList $ allDocs $
           xs                   -> throwErrorHere $ WrongNumberOfArgs "foldr" 3 (length xs))
     , ( "map"
       , "Given a function `f` and a sequence (list or vector) `xs`, returns a sequence\
-        \of the same size and type as `xs` but with `f` applied to all the elements."
+        \ of the same size and type as `xs` but with `f` applied to all the elements."
       , \case
           [fn, List ls] -> List <$> traverse (callFn fn) (pure <$> ls)
           [fn, Vec ls]  -> Vec <$> traverse (callFn fn) (pure <$> ls)
@@ -353,8 +353,8 @@ purePrimFns = fromList $ allDocs $
                   _      -> pure ff)
     , ( "type"
       , "Returns a keyword representing the type of the argument; one of:\
-        \`:atom`, `:keyword`, `:string`, `:number`, `:boolean`, `:list`,\
-        \`:vector`, `:function`, `:dict`, `:ref`, `:function`."
+        \ `:atom`, `:keyword`, `:string`, `:number`, `:boolean`, `:list`,\
+        \ `:vector`, `:function`, `:dict`, `:ref`, `:function`."
       , let kw' = pure . Keyword . Ident
         in oneArg "type" $ \case
              Atom _ -> kw' "atom"
@@ -386,8 +386,8 @@ purePrimFns = fromList $ allDocs $
           _        -> pure ff)
     , ( "member?"
       , "Given `v` and structure `s`, checks if `x` exists in `s`. The structure `s`\
-        \may be a list, vector or dict. If it is a list or a vector, it checks if `v`\
-        \is one of the items. If `s` is a dict, it checks if `v` is one of the keys."
+        \ may be a list, vector or dict. If it is a list or a vector, it checks if `v`\
+        \ is one of the items. If `s` is a dict, it checks if `v` is one of the keys."
       , \case
           [x, List xs] -> pure . Boolean $ elem x xs
           [x, Vec xs]  -> pure . Boolean . isJust $ Seq.elemIndexL x xs
@@ -405,7 +405,7 @@ purePrimFns = fromList $ allDocs $
           _       -> throwErrorHere $ TypeError "read-ref: argument must be a ref")
     , ( "write-ref"
       , "Given a reference `r` and a value `v`, updates the value stored in `r` to be\
-        \`v` and returns `v`."
+        \ `v` and returns `v`."
       , \case
           [Ref (Reference x), v] -> do
               st <- get
@@ -420,9 +420,9 @@ purePrimFns = fromList $ allDocs $
       , oneArg "show" (pure . String . renderPrettyDef))
     , ( "seq"
       , "Given a structure `s`, returns a sequence. Lists and vectors are returned\
-        \without modification while for dicts a vector of key-value-pairs is returned:\
-        \these are vectors of length 2 whose first item is a key and whose second item\
-        \is the associated value."
+        \ without modification while for dicts a vector of key-value-pairs is returned:\
+        \ these are vectors of length 2 whose first item is a key and whose second item\
+        \ is the associated value."
       , oneArg "seq" $
           \case
             x@(List _) -> pure x
@@ -444,7 +444,7 @@ purePrimFns = fromList $ allDocs $
       )
     , ( "verify-signature"
       , "Given a public key `pk`, a signature `s` and a message (string) `m`, checks\
-        \that `s` is a signature of `m` for the public key `pk`."
+        \ that `s` is a signature of `m` for the public key `pk`."
       , \case
           [keyv, sigv, String msg] -> do
             key <- fromRadOtherErr keyv


### PR DESCRIPTION
As most of all inputs are valid markdown the existing checks didn't serve any real purpose, but made us depend on Pandoc. Which broke the ghcjs build.