### PR TITLE
ghcjs: Fix build and repl

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -472,6 +472,11 @@ Documentation and testing
 Functions for creating and querying documentation of variables in scope,
 and testing functions.
 
+``help``
+~~~~~~~~
+
+Default help text.
+
 ``doc``
 ~~~~~~~
 

--- a/exe/GHCJS.hs
+++ b/exe/GHCJS.hs
@@ -75,8 +75,8 @@ primops = fromList $ allDocs [sendPrimop, receivePrimop]
   where
     sendPrimop =
       ( "send!"
-      , "Given a URL (string) and a value, sends the value `v` to the remote\
-        \ chain located at the URL for evaluation."
+      , "Given a URL (string) and a vector of value, sends the value `v` to the\
+        \ remote chain located at the URL for evaluation."
       , \case
          [String name, Vec v] -> do
              res <- liftIO $ runClientM' name (submit $ toList v)

--- a/exe/ReferenceDoc.hs
+++ b/exe/ReferenceDoc.hs
@@ -91,7 +91,7 @@ main = do
       , "map-values", "modify-map"]
     structs = ["member?"]
     refs = ["ref", "read-ref", "write-ref", "modify-ref"]
-    docs = ["doc", "doc!", "apropos!", "document", "is-test-env"]
+    docs = ["help", "doc", "doc!", "apropos!", "document", "is-test-env"]
     io =
       ["print!", "get-line!", "load!", "read-file!", "read-code!", "send-code!"
       , "send-prelude!", "subscribe-to!", "uuid!", "read-line!", "exit!"]
@@ -111,7 +111,7 @@ main = do
     typ s = "Functions for manipulating " <> s <> "."
 
     -- Functions which shouldn't be in the reference docs.
-    doNotInclude = ["head-shots", "get-head-shot", "eval__", "kim-trans", "pr-thread", "pr-trans"]
+    doNotInclude = ["head-shots", "get-head-shot", "eval__", "kim-trans", "pr-thread", "pr-trans", "_initial-prompt-text"]
 
     allFns =
          basics ++ maths ++ evalFns ++ envStuff ++ seqs ++ lists ++ vecs

--- a/package.yaml
+++ b/package.yaml
@@ -116,7 +116,7 @@ executables:
 
   radicle-client-ghcjs:
     main: GHCJS.hs
-    source-dirs: exe/Server
+    source-dirs: exe
     other-modules: API
     dependencies:
     - radicle
@@ -132,7 +132,13 @@ executables:
           buildable: true
         else:
           buildable: false
-    ghc-options: -main-is GHCJS -threaded
+    # XXX(xla): We need to remove the debug linking as it produces output js of
+    # aroud 27MB.
+    # We force debug linking as without it we encounter a runtime exception
+    # in ghcjs due to the metadata initializer only supporting objects with up
+    # to 100
+    # fields: https://github.com/ghcjs/ghcjs/issues/498#issuecomment-230725647
+    ghc-options: -main-is GHCJS -threaded -debug
 
   radicle-doc:
     main: Doc.hs

--- a/rad/prelude.rad
+++ b/rad/prelude.rad
@@ -54,13 +54,16 @@
     {:next-will-be (fn [] (+ 1 (read-ref i)))
      :next         (fn [] (modify-ref i (fn [x] (+ x 1))))}))
 
-(def _initial_prompt-text
+(def _initial-prompt-text
+  "Text used for greeting in the repl."
   "Welcome to radicle. Type (help) for help.")
 
-(def help (fn []
-  "radicle is a LISP-like language intended for programming chains, and interacting with those chains.
+(def help 
+  "Default help text."
+  (fn []
+    "radicle is a LISP-like language intended for programming chains, and interacting with those chains.
 
-  Type (doc '<name>) for further documentation of <name>."))
+    Type (doc '<name>) for further documentation of <name>."))
 
 
 (load! "rad/chains/issues.rad") ;; send-prelude! must be defined already

--- a/rad/prelude.rad
+++ b/rad/prelude.rad
@@ -54,4 +54,13 @@
     {:next-will-be (fn [] (+ 1 (read-ref i)))
      :next         (fn [] (modify-ref i (fn [x] (+ x 1))))}))
 
+(def _initial_prompt-text
+  "Welcome to radicle. Type (help) for help.")
+
+(def help (fn []
+  "radicle is a LISP-like language intended for programming chains, and interacting with those chains.
+
+  Type (doc '<name>) for further documentation of <name>."))
+
+
 (load! "rad/chains/issues.rad") ;; send-prelude! must be defined already

--- a/rad/repl.rad
+++ b/rad/repl.rad
@@ -2,15 +2,6 @@
 
 ;; The Repl
 
-
-(def _initial_prompt-text
-  "Welcome to radicle. Type (help) for help.")
-
-(def help (fn []
-  "radicle is a LISP-like language intended for programming chains, and interacting with those chains.
-
-  Type (doc '<name>) for further documentation of <name>."))
-
 (def read-line-or-exit! (fn []
   (def line (get-line!))
   (if (eq? line nil)

--- a/src/Radicle/Internal/Effects/Capabilities.hs
+++ b/src/Radicle/Internal/Effects/Capabilities.hs
@@ -60,7 +60,7 @@ class (Monad m) => ReadFile m where
 instance ReadFile (InputT IO) where
     readFileS = lift . requestFile
       where
-        requestFile :: Text -> IO Text
+        requestFile :: Text -> IO (Either Text Text)
         requestFile filename = do
             req <- newXMLHttpRequest
             openSimple req ("GET" :: Text) filename

--- a/stack-ghcjs.yaml
+++ b/stack-ghcjs.yaml
@@ -26,3 +26,4 @@ extra-deps:
 - ghcjs-dom-0.9.2.0
 - terminfo-0.4.1.2
 - ghcjs-dom-jsffi-0.9.2.0
+- uuid-1.3.13


### PR DESCRIPTION
For a while ghcjs wasn't up-to-date with the rest of the codebase which introduced incompatibilites with the prelude and broke the repl available online on radicle.xyz.

* fix signatures
* move `help` and `initial_prompt-text` to prelude
* use `-debug` linking for ghcjs to circumvent:
  https://github.com/ghcjs/ghcjs/issues/498#issuecomment-230725647
* uuid as extra deps