### PR TITLE
GitHub issues exporter

### DIFF
--- a/exe/GithubIssues.hs
+++ b/exe/GithubIssues.hs
@@ -2,32 +2,73 @@
 
 module GithubIssues (main) where
 
-import           Protolude
+import           Protolude hiding (state)
 
+import           Control.Error
 import qualified Data.Map.Strict as Map
+import           Data.Time
 import           GitHub.Data.Issues
+import           GitHub.Data.Name (Name(..))
 import qualified GitHub.Data.Options as GH
 import qualified GitHub.Endpoints.Issues as GH
+import qualified GitHub.Endpoints.Issues.Comments as GH
 
 import           Radicle
 
 main :: IO ()
 main = do
-  possibleIssues <- GH.issuesForRepo "oscoin" "radicle" mempty
-  case possibleIssues of
-       (Left error)   -> putStrLn $ "Error: " ++ show error
-       (Right issues) -> do
-         let v :: Value = toRad $ radIssue <$> toList issues
-         putStr $ renderPrettyDef v
+  is_ <- runExceptT (getIssues "oscoin" "radicle")
+  case is_ of
+    Right is -> putStrLn (renderPrettyDef (toRad (uncurry radIssue <$> is) :: Value))
+    Left e -> print e
 
-radIssue :: Issue -> Value
-radIssue Issue{..} = toRad $ Map.fromList
-    [ ( "body" :: Text, mt issueBody )
-    , ( "title", String issueTitle )
-    , ( "state", state issueState )
-    ]
+getIssues :: Text -> Text -> ExceptT GH.Error IO [(Issue, [IssueComment])]
+getIssues owner repo = do
+  is <- ExceptT $ GH.issuesForRepo (N owner) (N repo) GH.stateAll
+  let issues = filter notPR (toList is)
+  css <- traverse (getComments owner repo) issues
+  pure $ zip issues css
   where
-    mt :: Maybe Text -> Value
+    notPR Issue{ issuePullRequest = Nothing} = True
+    notPR _                                  = False
+
+getComments :: Text -> Text -> Issue -> ExceptT GH.Error IO [IssueComment]
+getComments owner repo Issue{..} = do
+  cs <- ExceptT $ GH.comments (N owner) (N repo) issueId
+  pure (toList cs)
+
+radIssue :: Issue -> [IssueComment] -> Value
+radIssue Issue{..} cs = dict $
+    [ ( [kword|github-author|], author issueUser )
+    , ( [kword|title|], String issueTitle )
+    , ( [kword|body|], mt issueBody )
+    , ( [kword|github-assignees|], toRad $ author <$> toList issueAssignees)
+    , ( [kword|state|], state issueState )
+    , ( [kword|labels|]
+      , toRad $ GH.untagName . GH.labelName <$> toList issueLabels
+      )
+    , ( [kword|created-at|], date issueCreatedAt )
+    , ( [kword|comments|], toRad (radComment <$> cs) )
+    ] <> catMaybes
+    [ ( [kword|closed-at|],) . date <$> issueClosedAt ]
+  where
     mt = String . fromMaybe ""
     state = \case GH.StateOpen -> [kword|open|]
                   GH.StateClosed -> [kword|closed|]
+
+radComment :: IssueComment -> Value
+radComment IssueComment{..} = dict
+  [ ( [kword|body|], String issueCommentBody )
+  , ( [kword|github-author|], author issueCommentUser )
+  , ( [kword|created-at|], date issueCommentCreatedAt )
+  ]
+
+dict = Dict . Map.fromList
+
+date :: UTCTime -> Value
+date = String . toS . formatTime defaultTimeLocale fmt
+  where
+    fmt = iso8601DateFormat (Just "%H:%M:%S")
+
+author :: GH.SimpleUser -> Value
+author = String . GH.untagName . GH.simpleUserLogin

--- a/exe/GithubIssues.hs
+++ b/exe/GithubIssues.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module GithubIssues (main) where
+
+import           Protolude
+
+import qualified Data.Map.Strict as Map
+import           GitHub.Data.Issues
+import qualified GitHub.Data.Options as GH
+import qualified GitHub.Endpoints.Issues as GH
+
+import           Radicle
+
+main :: IO ()
+main = do
+  possibleIssues <- GH.issuesForRepo "oscoin" "radicle" mempty
+  case possibleIssues of
+       (Left error)   -> putStrLn $ "Error: " ++ show error
+       (Right issues) -> do
+         let v :: Value = toRad $ radIssue <$> toList issues
+         putStr $ renderPrettyDef v
+
+radIssue :: Issue -> Value
+radIssue Issue{..} = toRad $ Map.fromList
+    [ ( "body" :: Text, mt issueBody )
+    , ( "title", String issueTitle )
+    , ( "state", state issueState )
+    ]
+  where
+    mt :: Maybe Text -> Value
+    mt = String . fromMaybe ""
+    state = \case GH.StateOpen -> [kword|open|]
+                  GH.StateClosed -> [kword|closed|]

--- a/exe/GithubIssues.hs
+++ b/exe/GithubIssues.hs
@@ -4,7 +4,6 @@ module GithubIssues (main) where
 
 import           Protolude hiding (state)
 
-import           Control.Error
 import qualified Data.Map.Strict as Map
 import           Data.Time
 import           GitHub.Data.Issues
@@ -12,34 +11,50 @@ import           GitHub.Data.Name (Name(..))
 import qualified GitHub.Data.Options as GH
 import qualified GitHub.Endpoints.Issues as GH
 import qualified GitHub.Endpoints.Issues.Comments as GH
+import           Options.Applicative
 
 import           Radicle
 
 main :: IO ()
 main = do
-  is_ <- runExceptT (getIssues "oscoin" "radicle")
+  Opts{..} <- execParser allOpts
+  let auth = GH.OAuth . toS <$> token
+  is_ <- runExceptT (getIssues auth owner repo)
   case is_ of
-    Right is -> putStrLn (renderPrettyDef (toRad (uncurry radIssue <$> is) :: Value))
+    Right is -> do
+      let t = renderPrettyDef (toRad (uncurry radIssue <$> is) :: Value)
+      case output of
+        Just file -> writeFile file t
+        Nothing   -> putStrLn t
     Left e -> print e
+  where
+    allOpts = info (opts <**> helper)
+        ( fullDesc
+       <> progDesc "Exports all issues from a GitHub repo as radicle data."
+       <> header "Radicle GitHub issues exporter"
+        )
 
-getIssues :: Text -> Text -> ExceptT GH.Error IO [(Issue, [IssueComment])]
-getIssues owner repo = do
-  is <- ExceptT $ GH.issuesForRepo (N owner) (N repo) GH.stateAll
+getIssues :: Maybe GH.Auth -> Text -> Text -> ExceptT GH.Error IO [(Issue, [IssueComment])]
+getIssues auth owner repo = do
+  is <- ExceptT $ GH.issuesForRepo' auth (N owner) (N repo) GH.stateAll
   let issues = filter notPR (toList is)
-  css <- traverse (getComments owner repo) issues
+  css <- traverse (getComments auth owner repo) issues
   pure $ zip issues css
   where
     notPR Issue{ issuePullRequest = Nothing} = True
     notPR _                                  = False
 
-getComments :: Text -> Text -> Issue -> ExceptT GH.Error IO [IssueComment]
-getComments owner repo Issue{..} = do
-  cs <- ExceptT $ GH.comments (N owner) (N repo) issueId
+getComments :: Maybe GH.Auth -> Text -> Text -> Issue -> ExceptT GH.Error IO [IssueComment]
+getComments auth owner repo Issue{..} = do
+  -- You would think we should query by issue ID, given the types, but nonono!
+  -- That would be too easy!
+  -- (This will probably be fixed upstream, soon, by me.)
+  cs <- ExceptT $ GH.comments' auth (N owner) (N repo) (GH.mkId (Proxy :: Proxy Issue) issueNumber)
   pure (toList cs)
 
 radIssue :: Issue -> [IssueComment] -> Value
 radIssue Issue{..} cs = dict $
-    [ ( [kword|github-author|], author issueUser )
+    [ ( [kword|author-github-username|], author issueUser )
     , ( [kword|title|], String issueTitle )
     , ( [kword|body|], mt issueBody )
     , ( [kword|github-assignees|], toRad $ author <$> toList issueAssignees)
@@ -63,6 +78,7 @@ radComment IssueComment{..} = dict
   , ( [kword|created-at|], date issueCommentCreatedAt )
   ]
 
+dict :: [(Value, Value)] -> Value
 dict = Dict . Map.fromList
 
 date :: UTCTime -> Value
@@ -72,3 +88,40 @@ date = String . toS . formatTime defaultTimeLocale fmt
 
 author :: GH.SimpleUser -> Value
 author = String . GH.untagName . GH.simpleUserLogin
+
+-- CLI
+
+data Opts = Opts
+    { owner  :: Text
+    , repo   :: Text
+    , output :: Maybe FilePath
+    , token  :: Maybe Text
+    }
+
+opts :: Parser Opts
+opts = Opts
+    <$> strArgument
+        ( metavar "OWNER"
+        <> help "GitHub owner username."
+        )
+    <*> strArgument
+        ( metavar "REPO"
+        <> help "GitHub repo name."
+        )
+    <*> optional (strOption
+        ( long "output"
+       <> short 'o'
+       <> metavar "FILE"
+       <> help "Output file with the GitHub issues as radicle data."
+        ))
+    <*> optional (strOption
+        ( long "token"
+       <> short 't'
+       <> metavar "TOKEN"
+       <> help
+           ( "GitHub personal access token. "
+          <> "If the repo has a large amount of issues, this will "
+          <> "be needed because of rate-limiting. "
+          <> "Go to https://github.com/settings/tokens to generate a token."
+           )
+        ))

--- a/package.yaml
+++ b/package.yaml
@@ -173,6 +173,7 @@ executables:
     - errors
     - time
     - github
+    - optparse-applicative
     ghc-options: -main-is GithubIssues
 
 default-extensions:

--- a/package.yaml
+++ b/package.yaml
@@ -170,6 +170,8 @@ executables:
         buildable: false
     dependencies:
     - radicle
+    - errors
+    - time
     - github
     ghc-options: -main-is GithubIssues
 

--- a/package.yaml
+++ b/package.yaml
@@ -161,6 +161,18 @@ executables:
     - data-default
     ghc-options: -main-is ReferenceDoc
 
+  radicle-github-issues:
+    main: GithubIssues.hs
+    source-dirs: exe/
+    other-modules: []
+    when:
+      - condition: impl(ghcjs)
+        buildable: false
+    dependencies:
+    - radicle
+    - github
+    ghc-options: -main-is GithubIssues
+
 default-extensions:
 - AutoDeriveTypeable
 - ConstraintKinds

--- a/src/Radicle.hs
+++ b/src/Radicle.hs
@@ -44,6 +44,7 @@ module Radicle
     , Reference(..)
     , Ident
     , ident
+    , kword
     , mkIdent
     , unsafeToIdent
     , fromIdent

--- a/src/Radicle/Internal.hs
+++ b/src/Radicle/Internal.hs
@@ -3,12 +3,13 @@ module Radicle.Internal
     ( module X
     , mkIdent
     , ident
+    , kword
     ) where
 
-import           Prelude (error)
 import           Protolude
 
 import           Language.Haskell.TH.Quote
+import qualified Language.Haskell.TH.Syntax as Syntax
 import           Radicle.Internal.Annotation as X
 import           Radicle.Internal.CLI as X
 import           Radicle.Internal.Core as X
@@ -27,13 +28,25 @@ mkIdent t = case runIdentity (M.runParserT valueP "" t) of
     Right (Atom i) -> pure i
     _              -> Nothing
 
+expQuot :: Text -> ([Char] -> Syntax.Q Syntax.Exp) -> QuasiQuoter
+expQuot name e = QuasiQuoter
+    { quoteExp = e
+    , quoteType = panic err
+    , quotePat = panic err
+    , quoteDec = panic err
+    }
+  where
+    err = name <> " only works for expressions"
+
 -- | A quasiquoter that checks that an identifier is valid at compile-time.
 ident :: QuasiQuoter
-ident = QuasiQuoter
-    { quoteExp = \s -> [| case mkIdent s of
-        Nothing -> error $ "Not a valid identifier: " <> s
-        Just i  -> i |]
-    , quoteType = error "ident only works for expressions"
-    , quotePat = error "ident only works for expressions"
-    , quoteDec = error "ident only works for expressions"
-    }
+ident =
+  expQuot "ident" $ \s -> [| case mkIdent s of
+    Nothing -> panic $ "Not a valid identifier: " <> s
+    Just i  -> i |]
+
+kword :: QuasiQuoter
+kword =
+  expQuot "kword" $ \s -> [| case mkIdent s of
+    Nothing -> panic $ "Not a valid keyword: " <> s
+    Just i -> Keyword i |]

--- a/src/Radicle/Internal.hs
+++ b/src/Radicle/Internal.hs
@@ -6,6 +6,7 @@ module Radicle.Internal
     , kword
     ) where
 
+import           Prelude (String)
 import           Protolude
 
 import           Language.Haskell.TH.Quote
@@ -28,7 +29,7 @@ mkIdent t = case runIdentity (M.runParserT valueP "" t) of
     Right (Atom i) -> pure i
     _              -> Nothing
 
-expQuot :: Text -> ([Char] -> Syntax.Q Syntax.Exp) -> QuasiQuoter
+expQuot :: Text -> (String -> Syntax.Q Syntax.Exp) -> QuasiQuoter
 expQuot name e = QuasiQuoter
     { quoteExp = e
     , quoteType = panic err
@@ -49,4 +50,4 @@ kword :: QuasiQuoter
 kword =
   expQuot "kword" $ \s -> [| case mkIdent s of
     Nothing -> panic $ "Not a valid keyword: " <> s
-    Just i -> Keyword i |]
+    Just i  -> Keyword i |]


### PR DESCRIPTION
Exports GitHub issues to a file that can be read by radicle:

```
stack exec radicle-github-issues -- oscoin radicle -o githubissues.rad -t <github-token>
```

Then you can access these issues in radicle, transform them, sign them, submit them to chains, etc.:

```
rad> (def issues (read (read-file! "githubissues.rad")))
()
rad> (nth 0 issues)
{:author-github-username "jkarni"
 :body "Something like \r\n\r\n```\r\n(def send-signed!\r\n  (fn [pk sk url expr]\r\n    (send! url {:payload   expr\r\n                :author    pk\r\n                :signature (gen-signature! sk (show expr))})))\r\n```\r\n\r\nAnd a corresponding `verify-sig`. In addition to simplifying things, this helps ensure signing and verifying signatures are done in a similar way.\r\n\r\nNote that then `rad/chains/issues.rad` and `rad/chains/issues-remote.rad` can be changed to use this."
 :comments []
 :created-at "2018-11-13T10:30:13"
 :github-assignees []
 :labels []
 :state :open
 :title "Version of `send!` that signs all expressions"}
```