### PR TITLE
Add callsignature with arg names to ref docs

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -15,28 +15,28 @@ value, etc.
 
 Checks if two values are equal.
 
-``not``
-~~~~~~~
+``(not x)``
+~~~~~~~~~~~
 
-True if 'arg' is #f, false otherwise.
+True if ``x`` is ``#f``, false otherwise.
 
-``and``
-~~~~~~~
+``(and x y)``
+~~~~~~~~~~~~~
 
-Returns 'arg2' if 'arg1' is not #f, otherwise returns 'arg1'
+Returns ``y`` if ``x`` is not ``#f``, otherwise returns ``x``
 
-``or``
-~~~~~~
+``(or x y)``
+~~~~~~~~~~~~
 
 Returns 'arg1' if 'arg1' is not #f, otherwise returns 'arg2'
 
-``all``
-~~~~~~~
+``(all xs)``
+~~~~~~~~~~~~
 
 Checks that all the items of a list are truthy.
 
-``some``
-~~~~~~~~
+``(some xs)``
+~~~~~~~~~~~~~
 
 Checks that there is a least one truthy value in a list.
 
@@ -127,13 +127,13 @@ values.
 Throws an exception. The first argument should be an atom used as a
 label for the exception, the second can be any value.
 
-``Y``
-~~~~~
+``(Y h)``
+~~~~~~~~~
 
 A combinator used to create recursive functions of one variable.
 
-``Y2``
-~~~~~~
+``(Y2 h)``
+~~~~~~~~~~
 
 A combinator used to create recursive functions of two variables.
 
@@ -147,8 +147,8 @@ Returns a JSON formatted string representing the input value.
 
 Checks if a string has the format of a UUID.
 
-``make-counter``
-~~~~~~~~~~~~~~~~
+``(make-counter)``
+~~~~~~~~~~~~~~~~~~
 
 Creates a stateful counter. Returns a dict with two keys: the function
 at ``:next-will-be`` will return the next number (without incrementing
@@ -228,8 +228,8 @@ an exception.
 Given a non-empty sequence, returns the sequence of all the elements but
 the first. If the sequence is empty, throws an exception.
 
-``empty?``
-~~~~~~~~~~
+``(empty? ls)``
+~~~~~~~~~~~~~~~
 
 True if 'seq' is empty, false otherwise.
 
@@ -238,33 +238,33 @@ True if 'seq' is empty, false otherwise.
 
 Adds an element to the front of a list.
 
-``reverse``
-~~~~~~~~~~~
+``(reverse ls)``
+~~~~~~~~~~~~~~~~
 
 Returns the reversed 'list'.
 
-``length``
-~~~~~~~~~~
+``(length xs)``
+~~~~~~~~~~~~~~~
 
 Returns the length of 'list'.
 
-``concat``
-~~~~~~~~~~
+``(concat list1 list2)``
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Concatenates 'list1' and 'list2'.
 
-``filter``
-~~~~~~~~~~
+``(filter pred ls)``
+~~~~~~~~~~~~~~~~~~~~
 
 Returns 'list' with only the elements that satisfy 'filter-cond'.
 
-``range``
-~~~~~~~~~
+``(range from to)``
+~~~~~~~~~~~~~~~~~~~
 
 Returns a list with all integers from 'start' to 'end', inclusive.
 
-``list-with-head``
-~~~~~~~~~~~~~~~~~~
+``(list-with-head x f g)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Given a value ``x``, and two functions ``f`` and ``g``, checks if ``x``
 is a list with a head. If so applies ``f`` to the head, otherwise calls
@@ -296,8 +296,8 @@ Sequences
 
 Functions for manipulating boths lists and vectors.
 
-``empty-seq?``
-~~~~~~~~~~~~~~
+``(empty-seq? xs)``
+~~~~~~~~~~~~~~~~~~~
 
 Returns true if the input is an empty sequence (either list or vector).
 
@@ -399,23 +399,23 @@ Given ``k`` and a dict ``d``, returns a dict with the same associations
 as ``d`` but without the key ``k``. If ``d`` isn't a dict then an
 exception is thrown.
 
-``dict-from-list``
-~~~~~~~~~~~~~~~~~~
+``(dict-from-list xs)``
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Creates a dictionary from a list of key-value pairs.
 
-``keys``
-~~~~~~~~
+``(keys d)``
+~~~~~~~~~~~~
 
 Given a ``dict``, returns a vector of its keys.
 
-``values``
-~~~~~~~~~~
+``(values d)``
+~~~~~~~~~~~~~~
 
 Given a ``dict``, returns a vector of its values.
 
-``rekey``
-~~~~~~~~~
+``(rekey old-key new-key mp)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Change the key from 'old-key' to 'new-key' in 'dict'. If 'new-key'
 already exists, it is overwritten.
@@ -426,19 +426,19 @@ already exists, it is overwritten.
 Given a function ``f`` and a dict ``d``, returns a dict with the same
 keys as ``d`` but ``f`` applied to all the associated values.
 
-``modify-map``
-~~~~~~~~~~~~~~
+``(modify-map key f mp)``
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Given a key, a function and a dict, applies the function to the value
 associated to that key.
 
-``delete-many``
-~~~~~~~~~~~~~~~
+``(delete-many ks d)``
+~~~~~~~~~~~~~~~~~~~~~~
 
 Delete several keys from a dict.
 
-``exclusive-dict-merge``
-~~~~~~~~~~~~~~~~~~~~~~~~
+``(exclusive-dict-merge m n)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Merges two dicts while checking for key conflicts. Returns
 ``{:merge   m :conflicts c}`` where ``m`` is the merged dict for all
@@ -455,33 +455,33 @@ Functions for manipulating sets.
 
 An empty set.
 
-``set/insert``
-~~~~~~~~~~~~~~
+``(set/insert x s)``
+~~~~~~~~~~~~~~~~~~~~
 
 Insert a value into a set.
 
-``set/delete``
-~~~~~~~~~~~~~~
+``(set/delete x s)``
+~~~~~~~~~~~~~~~~~~~~
 
 Delete a value from a set.
 
-``set/member?``
-~~~~~~~~~~~~~~~
+``(set/member? x s)``
+~~~~~~~~~~~~~~~~~~~~~
 
 Query if an value is an element of a set.
 
-``set/delete``
-~~~~~~~~~~~~~~
+``(set/delete x s)``
+~~~~~~~~~~~~~~~~~~~~
 
 Delete a value from a set.
 
-``set/from-seq``
-~~~~~~~~~~~~~~~~
+``(set/from-seq xs)``
+~~~~~~~~~~~~~~~~~~~~~
 
 Create a set from a sequence.
 
-``set/to-vec``
-~~~~~~~~~~~~~~
+``(set/to-vec s)``
+~~~~~~~~~~~~~~~~~~
 
 Convert a set to a vector.
 
@@ -504,8 +504,8 @@ Patterns
 Pattern matching is first-class in radicle so new patterns can easily be
 defined. These are the most essential.
 
-``match-pat``
-~~~~~~~~~~~~~
+``(match-pat pat v)``
+~~~~~~~~~~~~~~~~~~~~~
 
 The pattern matching dispatch function. This function defines how
 patterns are treated in ``match`` expressions. Atoms are treated as
@@ -514,36 +514,36 @@ patterns match dicts whose values at those keys match those patterns.
 Vectors of patterns match vectors of the same length, pairing the
 patterns and elements by index.
 
-``_``
-~~~~~
+``(_ v)``
+~~~~~~~~~
 
 The wildcard pattern.
 
-``/?``
-~~~~~~
+``(/? p)``
+~~~~~~~~~~
 
 Predicate pattern. Takes a predicate function as argument. Values match
 against this pattern if the predicate returns a truthy value.
 
-``/nil``
-~~~~~~~~
+``(/nil v)``
+~~~~~~~~~~~~
 
 Empty-list pattern.
 
-``/cons``
-~~~~~~~~~
+``(/cons x-pat xs-pat)``
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 A pattern for lists with a head and a tail.
 
-``/as``
-~~~~~~~
+``(/as var pat)``
+~~~~~~~~~~~~~~~~~
 
 As pattern. Takes a variable and a sub-pattern. If the subpattern
 matches then the whole pattern matches and furthermore the variable is
 bound to the matched value.
 
-``non-linear-merge``
-~~~~~~~~~~~~~~~~~~~~
+``(non-linear-merge m n)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The bindings merge strategy for non-linear patterns. Use this function
 to merge bindings returned by sub-patterns if you want your pattern to
@@ -570,8 +570,8 @@ Returns the current value of a ref.
 Given a reference ``r`` and a value ``v``, updates the value stored in
 ``r`` to be ``v`` and returns ``v``.
 
-``modify-ref``
-~~~~~~~~~~~~~~
+``(modify-ref r f)``
+~~~~~~~~~~~~~~~~~~~~
 
 Modify 'ref' by applying the provided function. Returns the new value.
 
@@ -587,15 +587,15 @@ The default evaluation function. Expects an expression and a radicle
 state. Return a list of length 2 consisting of the result of the
 evaluation and the new state.
 
-``eval``
-~~~~~~~~
+``(eval expr env)``
+~~~~~~~~~~~~~~~~~~~
 
 An eval in which one can use ``(:enter-chain url)`` to make the eval
 behave as that of a remote chain, and ``:send`` to send all enqueued
 expressions.
 
-``updatable-eval``
-~~~~~~~~~~~~~~~~~~
+``(updatable-eval sub-eval)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Given an evaluation function ``f``, returns a new one which augments
 ``f`` with a new command ``(update expr)`` which evaluates arbitrary
@@ -607,8 +607,8 @@ Documentation and testing
 Functions for creating and querying documentation of variables in scope,
 and testing functions.
 
-``help``
-~~~~~~~~
+``(help)``
+~~~~~~~~~~
 
 Default help text.
 
@@ -693,18 +693,18 @@ Evaluates the contents of a file. Each seperate radicle expression is
 
 Reads the contents of a file and returns it as a string.
 
-``read-code!``
-~~~~~~~~~~~~~~
+``(read-code! filename)``
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Read code (as data) from a file. Returns a vector of expressions
 
-``send-code!``
-~~~~~~~~~~~~~~
+``(send-code! chain-id filename)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Send code from a file to a remote chain.
 
-``send-prelude!``
-~~~~~~~~~~~~~~~~~
+``(send-prelude! chain-id)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Send the pure prelude to a chain.
 
@@ -721,8 +721,8 @@ then evaluated and passed to ``f``.
 
 Generates a random UUID.
 
-``read-line!``
-~~~~~~~~~~~~~~
+``(read-line!)``
+~~~~~~~~~~~~~~~~
 
 Read a single line of input and interpret it as radicle data.
 
@@ -743,18 +743,18 @@ Maybe
 Optionality is represented using ``[:Just x]`` for when the value
 exists, and ``:Nothing`` when it doesn't.
 
-``/Just``
-~~~~~~~~~
+``(/Just pat)``
+~~~~~~~~~~~~~~~
 
 Pattern which matches ``[:Just x]``.
 
-``maybe->>=``
-~~~~~~~~~~~~~
+``(maybe->>= v f)``
+~~~~~~~~~~~~~~~~~~~
 
 Monadic bind for the maybe monad.
 
-``maybe-foldlM``
-~~~~~~~~~~~~~~~~
+``(maybe-foldlM f i xs)``
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Monadic fold over the elements of a seq, associating to the left (i.e.
 from left to right) in the maybe monad.
@@ -764,48 +764,48 @@ Lenses
 
 Functional references into radicle values.
 
-``@``
-~~~~~
+``(@ k)``
+~~~~~~~~~
 
 Returns a lens targetting keys of dicts.
 
-``@nth``
-~~~~~~~~
+``(@nth n)``
+~~~~~~~~~~~~
 
 Lenses into the nth element of a vector
 
-``make-lens``
-~~~~~~~~~~~~~
+``(make-lens g s)``
+~~~~~~~~~~~~~~~~~~~
 
 Makes a lens out of a getter and a setter.
 
-``view``
-~~~~~~~~
+``(view lens target)``
+~~~~~~~~~~~~~~~~~~~~~~
 
 View a value through a lens.
 
-``view-ref``
-~~~~~~~~~~~~
+``(view-ref r lens)``
+~~~~~~~~~~~~~~~~~~~~~
 
 Like 'view', but for refs.
 
-``set``
-~~~~~~~
+``(set lens new-view target)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Set a value though a lens.
 
-``set-ref``
-~~~~~~~~~~~
+``(set-ref r lens v)``
+~~~~~~~~~~~~~~~~~~~~~~
 
 Like 'set', but for refs.
 
-``over``
-~~~~~~~~
+``(over lens f target)``
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Modify a value through a lens.
 
-``over-ref``
-~~~~~~~~~~~~
+``(over-ref r lens f)``
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Like 'over', but for refs.
 
@@ -814,13 +814,13 @@ Like 'over', but for refs.
 
 The identity lens.
 
-``..``
-~~~~~~
+``(.. lens1 lens2)``
+~~~~~~~~~~~~~~~~~~~~
 
 Compose two lenses.
 
-``...``
-~~~~~~~
+``(... lenses)``
+~~~~~~~~~~~~~~~~
 
 Compose multiple lenses.
 
@@ -831,68 +831,68 @@ Functions for creating or combining *validators*, which are functions
 which return the input unchanged or throw with an error message. These
 can be used for checking data before accepting it onto a chain.
 
-``validator/=``
-~~~~~~~~~~~~~~~
+``(validator/= x)``
+~~~~~~~~~~~~~~~~~~~
 
 Given ``x``, returns a validator that checks for equality with ``x``.
 
-``validator/member``
-~~~~~~~~~~~~~~~~~~~~
+``(validator/member xs)``
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Given a structure, returns a validator which checks for membership in
 the structure.
 
-``validator/type``
-~~~~~~~~~~~~~~~~~~
+``(validator/type t)``
+~~~~~~~~~~~~~~~~~~~~~~
 
 Checks that a value has a type. Expects a keyword describing the type,
 as returned by the ``type`` function.
 
-``validator/pred``
-~~~~~~~~~~~~~~~~~~
+``(validator/pred name p)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Given a description and a predicate, returns a validator that checks if
 the predicate is true.
 
-``validator/every``
-~~~~~~~~~~~~~~~~~~~
+``(validator/every v)``
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Given a validator, creates a new validator which checks that all the
 items in a sequence conform to it.
 
-``validator/and``
-~~~~~~~~~~~~~~~~~
+``(validator/and vs)``
+~~~~~~~~~~~~~~~~~~~~~~
 
 Given a sequence of validators ``vs``, returns a new validator which,
 given a value, checks if it conforms to all the validators in ``vs``.
 
-``validator/or``
-~~~~~~~~~~~~~~~~
+``(validator/or vs)``
+~~~~~~~~~~~~~~~~~~~~~
 
 Given a vector of validators ``vs``, returns a new validator which,
 given a value, checks if it conforms to at least one of the ``vs``.
 
-``validator/key``
-~~~~~~~~~~~~~~~~~
+``(validator/key k v)``
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Given a key and a validator, returns a validator which checks for the
 existence of that key and that the associated value conforms to the
 validator.
 
-``validator/keys``
-~~~~~~~~~~~~~~~~~~
+``(validator/keys ks)``
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Given a dict associating keys to validators, returns a validator which
 checks a dict for the existence of those keys, and that they conform to
 the associated validators.
 
-``validator/uuid``
-~~~~~~~~~~~~~~~~~~
+``(validator/uuid x)``
+~~~~~~~~~~~~~~~~~~~~~~
 
 Validates UUIDs.
 
-``validator/signed``
-~~~~~~~~~~~~~~~~~~~~
+``(validator/signed x)``
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Checks that a value is a dict with ``:signature`` and ``:author`` keys,
 and that the signature is valid for the rest of the dict for that
@@ -937,48 +937,48 @@ These functions can be used to simulate remote chains in the local REPL.
 This is useful for experimenting with inputs or even new evaluation
 functions before sending these to a remote chain.
 
-``new-chain``
-~~~~~~~~~~~~~
+``(new-chain url)``
+~~~~~~~~~~~~~~~~~~~
 
 Return an empty chain dictionary with the given url.
 
-``@var``
-~~~~~~~~
+``(@var ident)``
+~~~~~~~~~~~~~~~~
 
 A lens for variables in states of chains.
 
-``eval-in-chain``
-~~~~~~~~~~~~~~~~~
+``(eval-in-chain expr chain)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Evaluates 'expr' in the 'chain' and returns a dict with the ':result'
 and the resulting ':chain'.
 
-``enter-remote-chain``
-~~~~~~~~~~~~~~~~~~~~~~
+``(enter-remote-chain url env)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Make the eval behave as that of a remote chain. The second param is the
 env to return to after :quit.
 
-``update-chain``
-~~~~~~~~~~~~~~~~
+``(update-chain chain)``
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Takes a chain, and returns a new chain updated with the new expressions
 from the remote chain
 
-``add-quit``
-~~~~~~~~~~~~
+``(add-quit after-quit-state before-quit-eval)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Adds a ':quit' command to 'before-quit-eval', which switches to
 'after-quit-state' (and to the eval in that state)
 
-``add-send``
-~~~~~~~~~~~~
+``(add-send oeval)``
+~~~~~~~~~~~~~~~~~~~~
 
 Add a :send special form that sends the contents of *input to the
 chain*\ cur-chain
 
-``load-chain``
-~~~~~~~~~~~~~~
+``(load-chain url)``
+~~~~~~~~~~~~~~~~~~~~
 
 Takes a ``url``, and fetches the inputs of a remote chain and return a
 chain dictionary with the chain state.
@@ -993,53 +993,53 @@ List of files which together define the pure prelude.
 
 The pure prelude.
 
-``store-exprs``
-~~~~~~~~~~~~~~~
+``(store-exprs evalfn)``
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Store each new evaluated expression in '_inputs'
 
-``eval-fn-app``
-~~~~~~~~~~~~~~~
+``(eval-fn-app state f arg cb)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Given a state, a function, an argument and a callback, returns the
 result of evaluating the function call on the arg in the given state,
 while also calling the callback on the result.
 
-``state-machine-eval``
-~~~~~~~~~~~~~~~~~~~~~~
+``(state-machine-eval voters init-state init-transition)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Returns an eval which operates a state machine whose transition function
 may be updated. To update the transition function all voters must agree
 on it.
 
-``state-machine-input``
-~~~~~~~~~~~~~~~~~~~~~~~
+``(state-machine-input state i)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Handle an input in the morphing state-machine.
 
-``state-machine-new-trans``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``(state-machine-new-trans state func)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Trigger a new vote.
 
-``state-machine-agree``
-~~~~~~~~~~~~~~~~~~~~~~~
+``(state-machine-agree state voters userid)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Vote to agree on a new transition function.
 
-``state-machine-disagree``
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+``(state-machine-disagree state voters userid)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Vote to disagree on a new transition function.
 
-``simple-trans``
-~~~~~~~~~~~~~~~~
+``(simple-trans f)``
+~~~~~~~~~~~~~~~~~~~~
 
 Given a function ``f``, makes a transition function who's output is also
 the next state.
 
-``update-chain-ref``
-~~~~~~~~~~~~~~~~~~~~
+``(update-chain-ref chain-ref)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Update a ref containing a chain with the new expressions from the remote
 chain

--- a/rad/prelude/bool.rad
+++ b/rad/prelude/bool.rad
@@ -3,21 +3,15 @@
 ;; not
 
 (def not
+  "True if `x` is `#f`, false otherwise."
   (fn [x] (if x #f #t)))
-
-(document 'not
-  '(("arg" any))
-  "True if 'arg' is #f, false otherwise.")
 
 ;; and
 
 (def and
+  "Returns `y` if `x` is not `#f`, otherwise returns `x`"
   (fn [x y]
     (if x y x)))
-
-(document 'and
-  '(("arg1" any) ("arg2" any))
-  "Returns 'arg2' if 'arg1' is not #f, otherwise returns 'arg1'")
 
 (:test "and"
   [ (and #t #t) ==> #t ]


### PR DESCRIPTION
We now show how functions are called in the reference documentation. This also makes it possible to reference the variable names in the doc string.