### PR TITLE
CI build fails if ref docs not checked in

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -48,7 +48,12 @@ steps:
     args:
     - '-c'
     - |
+      mv docs/source/reference.rst oldref
       stack exec radicle-ref-doc
+      if ! (diff oldref docs/source/reference.rst); then
+        echo "Reference docs are not checked in"
+        exit 1
+      fi
 
   - id: "Save cache"
     name: gcr.io/cloud-builders/gsutil


### PR DESCRIPTION
The CI build now fails if the reference docs that are checked in do not match the reference docs that were build.

You can see a failed build here: https://console.cloud.google.com/cloud-build/builds/01d89e45-6bfc-471c-9008-1e57ad90a253?project=opensourcecoin