### PR TITLE
radicle binary can read program from stdin

### DIFF
--- a/src/Radicle/Internal/Effects/Capabilities.hs
+++ b/src/Radicle/Internal/Effects/Capabilities.hs
@@ -48,6 +48,8 @@ instance Exit m => Exit (Lang m) where
 class Monad m => CurrentTime m where
   currentTime :: m UTCTime
 
+instance CurrentTime IO where
+  currentTime = getCurrentTime
 instance CurrentTime (InputT IO) where
   currentTime = liftIO getCurrentTime
 instance CurrentTime m => CurrentTime (Lang m) where


### PR DESCRIPTION
Re-apply chanages that were supposed to land in #208 but got lost in a force push.

We add the possibility for a radicle to read a program from stdin by providing the - argument. In that case the evaluation is not run in the InputT monad but just in IO