### PR TITLE
Improve documentation and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,37 @@
 # radicle
 
-> because 'tis the Origin of the Root... The Radicle is likewise called  the
-seminal Root.
-> - Vallemont, *Curiosities of nature and art in husbandry and gardening* (1707)
+> because 'tis the Origin of the Root... The Radicle is likewise called the seminal Root.
+> — Vallemont, *Curiosities of nature and art in husbandry and gardening* (1707)
 
 A LISP in the spirit of [Black](http://pllab.is.ocha.ac.jp/~asai/Black/) and
 other colors. Easily define and interact with shared and upgradable state
 machines.
 
-## Installation
-
-Install [stack](https://docs.haskellstack.org/en/stable/install_and_upgrade/). Then:
-```
-stack build
-```
-
-(You'll need libpq-dev/postgresql to build the server. See [GettingStarted](https://radicle.readthedocs.io/en/latest/guide/GettingStarted.html) for more info.
-
-## How to run tests
-
-```
-stack test
-```
-
-## How to run executables
-
-Running scripts and a REPL are the same thing - some scripts (in particular
-`rad/repl.rad`) just *define* a REPL.
-
-You should probably run the client against radicle.xyz for fuller
-functionality.
-
-```
-stack exec radicle-client -- --config rad/repl.rad
-```
-
-## More
-
-Radicle has a [webpage](http://radicle.xyz/), and a [guide](http://docs.radicle.xyz) which
+Radicle has a [webpage](http://radicle.xyz/), and a [Getting Started
+Guide](http://docs.radicle.xyz/en/latest/guide/GettingStarted.html) which
 contain a lot more information on `radicle`.
 
+## Installation
+
+You need [stack](https://docs.haskellstack.org/en/stable/install_and_upgrade/) and `libpq-dev`.
+
+```
+stack install
+```
+
+## Usage
+
+```
+radicle ./rad/repl.rad
+rad> (print! "hello world")
+rad> (def-rec fac (fn [n] (if (eq? n 0) 1 (* n (fac (- n 1))))))
+rad> (fac 6)
+```
+
+## Development
+
+You can run tests with `stack test`.
+
+The documentation is build with `make -C docs html`. Reference documentation for
+Radicle code must be regenerated with `stack run radicle-doc-ref` and checked
+into version control.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,6 +17,8 @@
 # sys.path.insert(0, os.path.abspath('.'))
 
 from recommonmark.parser import CommonMarkParser
+from pygments.lexers.jvm import ClojureLexer
+from sphinx.highlighting import lexers
 
 # -- Project information -----------------------------------------------------
 
@@ -73,6 +75,9 @@ exclude_patterns = []
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None
+
+lexers['radicle'] = ClojureLexer()
+
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/guide/GettingStarted.rst
+++ b/docs/source/guide/GettingStarted.rst
@@ -28,7 +28,7 @@ http://git.oscoin.io/radicle:
 
 .. code-block:: bash
 
-    git clone http://git.oscoin.io/radicle
+    git clone https://github.com/oscoin/radicle.git
     cd radicle
     stack build
     stack install
@@ -46,4 +46,4 @@ file (included in the repository):
 
 .. code-block:: bash
 
-    radicle --config rad/repl.rad
+    radicle rad/repl.rad

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -16,7 +16,7 @@ repository. We'll see how to define the format of issues that can be created;
 how to define rights and permissions for certain types of interaction; and
 how to allow for future changes to the chain. 
 
-::
+.. code-block:: radicle
 
      (load! "rad/prelude.rad")
      (def issues (ref { :open nil :closed nil }))


### PR DESCRIPTION
* Fix outdated usage examples
* Move link to website and Getting Started Guide up
* Move information for developers to the end
* Better usage example# Requesting a pull to oscoin:master from oscoin:doc-fixes
* Add pygments lexer for Radicle