### PR TITLE
Add 'weeder' to CI

### DIFF
--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -1,0 +1,50 @@
+- package:
+  - name: radicle
+  - section:
+    # BEGIN ignore everything because this target is not build by
+    # default.
+    - name: exe:radicle-client-ghcjs
+    - message:
+      - name: Module not compiled
+      - module: GHCJS.hs
+    - message:
+      - name: Redundant build-depends entry
+      - depends:
+        - bytestring
+        - exceptions
+        - ghcjs-base
+        - ghcjs-dom
+        - http-media
+        - protolude
+        - radicle
+        - servant
+        - servant-client-ghcjs
+    # END
+  - section:
+    - name: test:spec
+    - message:
+      - name: Redundant build-depends entry
+      - depends:
+        # Required as compiler plugin
+        - tasty-discover
+    - message:
+      # BEGIN export all for ease of debugging
+      - name: Weeds exported
+      - module:
+        - name: Radicle.Internal.TestCapabilities
+        - identifier:
+          - TestLang
+          - clientPrimFns
+          - runTestWith'
+      - module:
+        - name: Radicle.Tests
+        - identifier:
+          - ansi
+          - assertReplInteraction
+          - atom
+          - int
+          - kw
+          - parseTest
+          - prettyEither
+          - stackTraceLines
+      # END

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,7 +18,7 @@ steps:
     - |
       stack config set system-ghc --global true
       stack config set install-ghc --global false
-      stack install stylish-haskell hlint
+      stack install stylish-haskell hlint weeder
 
   - id: "Format"
     name: 'haskell:8.4.3'
@@ -41,7 +41,14 @@ steps:
       apt-get -y install postgresql libpq-dev
       stack build --fast --test --no-terminal --pedantic
 
+  - id: "Lint (weeder)"
+    waitFor: ["Test & Build"]
+    name: 'haskell:8.4.3'
+    env: ["STACK_ROOT=/workspace/.stack"]
+    args: ["stack", "exec", "--", "weeder", "--match"]
+
   - id: "Build reference document"
+    waitFor: ["Test & Build"]
     name: 'haskell:8.4.3'
     env: ['STACK_ROOT=/workspace/.stack']
     entrypoint: bash

--- a/package.yaml
+++ b/package.yaml
@@ -12,9 +12,6 @@ dependencies:
 - base >=4 && <5
 - protolude
 
-when:
- - condition: impl(ghcjs)
-   dependencies: ghcjs-dom
 ghc-options:
   -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
 
@@ -28,20 +25,16 @@ library:
   - bytestring
   - containers
   - cryptonite
-  - data-default
-  - deriving-compat
   - directory
   - filepath
   - generics-eot
   - haskeline
   - http-client
-  - http-media
   - megaparsec
   - mtl
   - pointed
   - prettyprinter
   - prettyprinter-ansi-terminal
-  - recursion-schemes
   - servant
   - servant-client
   - scientific
@@ -62,13 +55,11 @@ tests:
     - radicle
     - containers
     - cryptonite
-    - directory
     - filemanip
     - interpolate
     - megaparsec
     - QuickCheck
     - quickcheck-instances
-    - safe
     - scientific
     - serialise
     - string-qq
@@ -86,7 +77,6 @@ tests:
     other-modules:
     - Paths_radicle
     dependencies:
-    - radicle
     - doctest
     - Glob
     - hpack
@@ -99,7 +89,6 @@ executables:
     dependencies:
     - radicle
     - directory
-    - exceptions
     - optparse-applicative
     when:
       - condition: impl(ghcjs)
@@ -143,6 +132,7 @@ executables:
       - condition: impl(ghcjs)
         then:
           buildable: true
+          dependencies: ghcjs-dom
         else:
           buildable: false
     # XXX(xla): We need to remove the debug linking as it produces output js of
@@ -194,7 +184,6 @@ executables:
     dependencies:
     - radicle
     - containers
-    - errors
     - time
     - github
     - optparse-applicative


### PR DESCRIPTION
Add [weeder][1] to our CI pipeline. Weeder checks for unused dependencies and exports. This forces us to remove some unused dependencies.

[1]: https://github.com/ndmitchell/weeder