### PR TITLE
Fail tests when repl.rad fails to evaluate

### DIFF
--- a/src/Radicle/Internal/Core.hs
+++ b/src/Radicle/Internal/Core.hs
@@ -69,8 +69,11 @@ data LangErrorData r =
     | NonHashableKey
     | OtherError Text
     | ParseError (Par.ParseError Char Void)
+    -- | Raised if @(throw ident value)@ is evaluated. Arguments are
+    -- provided by the call to @throw@.
     | ThrownError Ident r
     | PatternMatchError PatternMatchError
+    -- | Raised if the effectful @exit!@ primitive is evaluated.
     | Exit
     deriving (Eq, Show, Read, Generic, Functor)
 


### PR DESCRIPTION
Before the tests failed with cryptig errors like `[] does not equal ["#t"]` when `repl.rad` failed to evaluate. Now we throw the evaluation exception to give more information. To this end we replace `runInRepl` with `assertReplInteraction`.