### PR TITLE
Nicer error message and stack traces

### DIFF
--- a/src/Radicle/Internal/Annotation.hs
+++ b/src/Radicle/Internal/Annotation.hs
@@ -4,8 +4,9 @@ module Radicle.Internal.Annotation where
 
 import           Codec.Serialise (Serialise)
 import           Data.Copointed (Copointed(..))
-import           Data.Text (pack)
-import           Protolude
+import qualified Data.Text as T
+import           GHC.Stack
+import           Protolude hiding (SrcLoc)
 import qualified Text.Megaparsec.Pos as Par
 
 import           Radicle.Internal.Orphans ()
@@ -54,7 +55,10 @@ data SrcPos = SrcPos Par.SourcePos
 instance Serialise SrcPos
 
 thisPos :: HasCallStack => SrcPos
-thisPos = InternalPos (pack (prettyCallStack callStack))
+thisPos = InternalPos $ T.intercalate "\n" (map prettyCallSite $ getCallStack callStack)
+  where
+    prettyCallSite (f, SrcLoc{..}) =
+        toS $ srcLocFile <> show srcLocStartLine <> ":" <> show srcLocStartCol <> " " <> f
 
 data WithPos a = WithPos SrcPos a
     deriving (Read, Show, Generic, Functor, Foldable, Traversable)
@@ -73,4 +77,3 @@ instance Copointed WithPos where
 
 instance Annotation WithPos where
     toAnnotation = WithPos thisPos
-

--- a/src/Radicle/Internal/Annotation.hs
+++ b/src/Radicle/Internal/Annotation.hs
@@ -58,7 +58,7 @@ thisPos :: HasCallStack => SrcPos
 thisPos = InternalPos $ T.intercalate "\n" (map prettyCallSite $ getCallStack callStack)
   where
     prettyCallSite (f, SrcLoc{..}) =
-        toS $ srcLocFile <> show srcLocStartLine <> ":" <> show srcLocStartCol <> " " <> f
+        toS $ srcLocFile <> ":" <> show srcLocStartLine <> ":" <> show srcLocStartCol <> " " <> f
 
 data WithPos a = WithPos SrcPos a
     deriving (Read, Show, Generic, Functor, Foldable, Traversable)

--- a/src/Radicle/Internal/Pretty.hs
+++ b/src/Radicle/Internal/Pretty.hs
@@ -72,7 +72,7 @@ instance Pretty Ann.SrcPos where
 
 instance PrettyV r => PrettyV (LangError r) where
     prettyV (LangError stack err) = vsep $
-        [prettyV err, "Call stack:"] ++ map pretty (reverse stack)
+        [prettyV err, indent 2 $ vsep $ map pretty (reverse stack)]
 
 instance PrettyV r => PrettyV (LangErrorData r) where
     prettyV v = case v of


### PR DESCRIPTION
We improve the pretty printing of `LangErr` which controls how errors are presented to the user in the repl.

Before

    rad> for
    Unknown identifier: for
    Call stack:
    CallStack (from HasCallStack):
      throwErrorHere, called at src/Radicle/Internal/Core.hs:442:16 in radicle-0.0.0-APXwyK9mqT76kQ4jVXGKMS:Radicle.Internal.Core
    [read-primop]:1:4
    [load! rad/prelude/test.rad]:44:23
    [load! rad/prelude/test.rad]:44:24
    [load! rad/chain.rad]:183:27
    [load! rad/chain.rad]:183:28
    CallStack (from HasCallStack):
      annotate, called at src/Radicle/Internal/Core.hs:282:26 in radicle-0.0.0-APXwyK9mqT76kQ4jVXGKMS:Radicle.Internal.Core
      Lambda, called at src/Radicle/Internal/Core.hs:506:23 in radicle-0.0.0-APXwyK9mqT76kQ4jVXGKMS:Radicle.Internal.Core

After

    rad> foo
    Unknown identifier: foo
      src/Radicle/Internal/Core.hs442:16 throwErrorHere
      [read-primop]:1:4
      [load! rad/prelude/test.rad]:44:23
      [load! rad/prelude/test.rad]:44:24
      [load! rad/chain.rad]:183:27
      [load! rad/chain.rad]:183:28
      src/Radicle/Internal/Core.hs:282:26 annotate
      src/Radicle/Internal/Core.hs:506:23 Lambda