### PR TITLE
Build `radicle-server` image in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ docs/build/
 docs/build/
 TAGS
 rad/my-keys.rad
+/images

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,6 @@
 timeout: 1800s # Cache misses are slow to rebuild
+images:
+- 'eu.gcr.io/$PROJECT_ID/radicle-server'
 steps:
   - id: "Load cache"
     name: gcr.io/cloud-builders/gsutil
@@ -30,18 +32,23 @@ steps:
     env: ['STACK_ROOT=/workspace/.stack']
     args: ['stack', 'exec', '--', 'hlint', '.']
 
-  - id: "Test & Build"
+  - id: "Build & Test"
     name: 'haskell:8.4.3'
     env: ['STACK_ROOT=/workspace/.stack']
     entrypoint: bash
     args:
     - '-c'
     - |
-      apt-get update
-      apt-get -y install postgresql libpq-dev
-      stack build --fast --test --no-terminal --pedantic
+      apt-get -qq update
+      apt-get -yqq install libpq-dev
+      stack build --fast
+
+      cp -a scripts/docker-build-shim.sh /usr/bin/docker
+      stack image container
 
   - id: "Build reference document"
+    waitFor:
+    - "Build & Test"
     name: 'haskell:8.4.3'
     env: ['STACK_ROOT=/workspace/.stack']
     entrypoint: bash
@@ -55,7 +62,15 @@ steps:
         exit 1
       fi
 
+  - id: "Build radicle-server image"
+    waitFor:
+    - "Build & Test"
+    name: 'gcr.io/cloud-builders/docker'
+    args: [ 'build', '-t', 'eu.gcr.io/$PROJECT_ID/radicle-server', './images/radicle-server' ]
+
   - id: "Save cache"
+    waitFor:
+    - "Build & Test"
     name: gcr.io/cloud-builders/gsutil
     entrypoint: 'bash'
     args:
@@ -63,4 +78,3 @@ steps:
     - |
       source scripts/ci.sh
       save-cache
-

--- a/scripts/docker-build-shim.sh
+++ b/scripts/docker-build-shim.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# This is a shim for `docker build -t TAG DIR` that copies `DIR` to
+# `images/TAG`.
+#
+# It is in the cloud build when running `stack image container`. This
+# allows us to build the image in a separate step.
+
+set -e
+
+if [ $1 != "build" ]; then
+  echo "docker-build-shim: Unknown command $1"
+  exit 1
+fi
+
+if [ $2 != "-t" ]; then
+  echo "docker-build-shim: Unknown option $2"
+  exit 1
+fi
+
+image_tag=$3
+image_dir=$4
+
+target_dir=./images/$image_tag
+mkdir -p $target_dir
+cp -a $image_dir/* $target_dir
+echo "Added image source $target_dir"

--- a/stack.yaml
+++ b/stack.yaml
@@ -47,9 +47,9 @@ extra-deps:
 image:
   containers:
     - base: "fpco/ubuntu-with-libgmp:14.04"
-      name: "radicle/server"
+      name: "radicle-server"
       executables:
-        - server
+        - radicle-server
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
We build and push the `eu.gcr.io/opensourcecoin/radicle-server` image that runs the radicle server.

To achieve this we need a bit of trickery when using `stack image container`.

We also optimize the CI build a bit:
- Parallelize the jobs after “Build & Test” with `waitFor` key
- Silence `apt-get` with `-qq` flag
- Remove superfluous `postgresql` dependency