### PR TITLE
Only print colors when ANSI is supported

### DIFF
--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -39,7 +39,6 @@
       - module:
         - name: Radicle.Tests
         - identifier:
-          - ansi
           - assertReplInteraction
           - atom
           - int

--- a/exe/RadicleExe.hs
+++ b/exe/RadicleExe.hs
@@ -1,12 +1,14 @@
 module RadicleExe (main) where
 
-import           Options.Applicative
 import           Prelude (String)
 import           Protolude hiding (TypeError, option, sourceFile)
-import           Radicle
+
+import           Options.Applicative
 import           System.Directory (doesFileExist)
 
+import           Radicle
 import           Radicle.Internal.HttpStorage
+import           Radicle.Internal.Pretty (putPrettyAnsi)
 
 main :: IO ()
 main = do
@@ -19,9 +21,9 @@ main = do
         (result, _state) <- runLang bindings prog
         case result of
             Left (LangError _ Exit) -> pure ()
-            Left e                  -> do putStrLn $ renderAnsi e
+            Left e                  -> do putPrettyAnsi e
                                           exitWith (ExitFailure 1)
-            Right v                 -> putStrLn $ renderAnsi v
+            Right v                 -> putPrettyAnsi v
     else do
         src <- readSource (sourceFile opts')
         hist <- case histFile opts' of

--- a/package.yaml
+++ b/package.yaml
@@ -22,6 +22,7 @@ library:
   source-dirs: src
   dependencies:
   - aeson
+  - ansi-terminal
   - bytestring
   - containers
   - cryptonite

--- a/src/Radicle.hs
+++ b/src/Radicle.hs
@@ -71,7 +71,6 @@ module Radicle
     , renderPretty
     , renderPrettyDef
     , renderCompactPretty
-    , renderAnsi
     -- ** Re-exports
     , PageWidth(..)
     , Pretty

--- a/src/Radicle/Internal/Effects.hs
+++ b/src/Radicle/Internal/Effects.hs
@@ -6,8 +6,6 @@ import           Protolude hiding (TypeError, toList)
 
 import qualified Data.Map as Map
 import qualified Data.Text as T
-import           Data.Text.Prettyprint.Doc (reAnnotate)
-import           Data.Text.Prettyprint.Doc.Render.Terminal (putDoc)
 import qualified Data.Time as Time
 import           GHC.Exts (IsList(..))
 import           System.Console.Haskeline
@@ -57,7 +55,7 @@ repl histFile preFileName preCode bindings = do
         $ void $ interpretMany preFileName preCode
     case r of
         Left (LangError _ Exit) -> pure ()
-        Left e                  -> putDoc $ reAnnotate toAnsi $ prettyV e
+        Left e                  -> putPrettyAnsi e
         Right ()                -> pure ()
 
 completion :: Monad m => CompletionFunc m
@@ -82,7 +80,7 @@ replPrimFns = fromList $ allDocs $
       , "Pretty-prints a value."
       , \case
         [x] -> do
-            putStrS (renderAnsi x)
+            putPrettyAnsi x
             pure nil
         xs  -> throwErrorHere $ WrongNumberOfArgs "print!" 1 (length xs))
 
@@ -144,10 +142,10 @@ replPrimFns = fromList $ allDocs $
                                 (\err -> case err of
                                    LangError _ Exit -> pure (pure nil)
                                    LangError _ (Impossible _) -> do
-                                       putStrS (renderAnsi err)
+                                       putPrettyAnsi err
                                        throwError err
                                    _ -> do
-                                       putStrS (renderAnsi err)
+                                       putPrettyAnsi err
                                        put st
                                        pure (loop action))
                         go = do

--- a/src/Radicle/Internal/Effects/Capabilities.hs
+++ b/src/Radicle/Internal/Effects/Capabilities.hs
@@ -9,6 +9,7 @@ import           Protolude
 
 import           Data.Text.Prettyprint.Doc (PageWidth)
 import           Data.Time
+import           System.Console.ANSI (hSupportsANSI)
 import           System.Console.Haskeline hiding (catch)
 import           System.IO (isEOF)
 #ifdef ghcjs_HOST_OS
@@ -33,12 +34,18 @@ instance (MonadException m) => Stdin (InputT m) where
 
 class (Monad m) => Stdout m where
     putStrS :: Text -> m ()
+    -- | Return true if we can output ANSI control characters with
+    -- 'putStrS'.
+    supportsANSI :: m Bool
 instance {-# OVERLAPPABLE #-} Stdout m => Stdout (Lang m) where
     putStrS = lift . putStrS
+    supportsANSI = lift supportsANSI
 instance Stdout IO where
     putStrS = putStrLn
+    supportsANSI = hSupportsANSI stdout
 instance (MonadException m, Monad m) => Stdout (InputT m) where
     putStrS = outputStrLn . toS
+    supportsANSI = pure True
 
 class (Monad m) => Exit m where
     exitS :: m ()

--- a/test/spec/Radicle/Internal/TestCapabilities.hs
+++ b/test/spec/Radicle/Internal/TestCapabilities.hs
@@ -141,6 +141,7 @@ instance {-# OVERLAPPING #-} Stdin TestLang where
 instance {-# OVERLAPPING #-} Stdout TestLang where
     putStrS t = lift $
         modify (\ws -> ws { worldStateStdout = t:worldStateStdout ws })
+    supportsANSI = pure False
 
 instance {-# OVERLAPPING #-} ReadFile TestLang where
   readFileS fn = do

--- a/test/spec/Radicle/Tests.hs
+++ b/test/spec/Radicle/Tests.hs
@@ -599,11 +599,6 @@ test_pretty =
             pp = renderPrettyDef v
             v_ = parseTest pp
         in v_ == Right v
-    , testCase "renderAnsi renders colours" $ do
-        renderAnsi (kw "hello") @?= "\ESC[0;95m:hello\ESC[0m"
-        renderAnsi (asValue (String "hello")) @?= "\ESC[0;92m\"hello\"\ESC[0m"
-        renderAnsi (int 42) @?= "\ESC[0;93m42\ESC[0m"
-        renderAnsi (asValue (Boolean True)) @?= "\ESC[0;96m#t\ESC[0m"
     ]
   where
     apl cols = AvailablePerLine cols 1
@@ -842,9 +837,4 @@ assertReplInteraction input expected = do
         Right _  -> pure ()
     -- In addition to the output of the lines tested, tests get
     -- printed, so we take only the last few output lines.
-    reverse (take (length expected) output) @=? map ansi expected
-
-ansi :: Text -> Text
-ansi t = case parseTest t of
-    Left _ -> panic "Error adding colour codes to value string: original string does not parse."
-    Right v -> renderAnsi v
+    reverse (take (length expected) output) @=? expected


### PR DESCRIPTION
We want to suppress the colored output when we are not dealing with a TTY, for example if we are redirecting to a file or another program.