### PR TITLE
Reorganize self testing in Radicle

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -90,7 +90,7 @@ evaluation and the new state.
 ``(eval expr env)``
 ~~~~~~~~~~~~~~~~~~~
 
-The evaluation function.
+Evaluation function that adds :test macro to register tests.
 
 ``ref``
 ~~~~~~~

--- a/exe/ReferenceDoc.hs
+++ b/exe/ReferenceDoc.hs
@@ -36,7 +36,7 @@ main = do
              interpret
                "reference-doc"
                (   "(do"
-                <> "(file-module! \"rad/prelude/test.rad\") (import prelude/test :unqualified)"
+                <> "(file-module! \"rad/prelude/test-eval.rad\") (import prelude/test-eval '[eval tests] :unqualified)"
                 <> foldMap (\m -> "(file-module! \"rad/" <> m <> ".rad\")") (modules content)
                 <> "(get-current-env))")
                replBindings
@@ -91,7 +91,7 @@ main = do
       vs -> panic $ "The following functions have no documentation strings: " <> T.intercalate ", " vs
 
     checkAllInReference content e =
-      let notDocumented = Map.keys e \\ (primFns content ++ modules content ++ ["prelude/test"]) in
+      let notDocumented = Map.keys e \\ (primFns content ++ modules content ++ ["prelude/test-eval", "tests"]) in
       if null notDocumented
         then pure ()
       else panic $ "The following functions need to be added to the reference doc: " <> T.intercalate ", " notDocumented

--- a/rad/monadic/issues.rad
+++ b/rad/monadic/issues.rad
@@ -132,7 +132,8 @@
 (:test
  "The monadic issues chain works."
  [:setup
-  (do (create-issues-chain!)
+  (do (write-ref issues-chain (chain/new-chain "http://localhost:8024/chains/fxoo"))
+      (create-issues-chain!)
       (simple-create-issue! "title0" "body0")
       (simple-create-issue! "title1" "body1")
       (simple-add-comment! 0 "comment0")

--- a/rad/prelude.rad
+++ b/rad/prelude.rad
@@ -1,5 +1,5 @@
-(file-module! "rad/prelude/test.rad")
-(import prelude/test '[eval] :unqualified)
+(file-module! "rad/prelude/test-eval.rad")
+(import prelude/test-eval '[eval tests] :unqualified)
 
 (file-module! "rad/prelude/basic.rad")
 (file-module! "rad/prelude/patterns.rad")
@@ -16,6 +16,7 @@
 (file-module! "rad/prelude/state-machine.rad")
 (file-module! "rad/prelude/validation.rad")
 (file-module! "rad/prelude/util.rad")
+(file-module! "rad/prelude/test.rad")
 
 (import prelude/basic :unqualified)
 (import prelude/patterns :unqualified)

--- a/rad/prelude/chain.rad
+++ b/rad/prelude/chain.rad
@@ -213,8 +213,8 @@
 
 (def pure-prelude-code
   "Code for the pure prelude. Useful as the first inputs to a new chain."
-  (<> [(file-to-module "rad/prelude/test.rad")
-       '(import prelude/test :unqualified)]
+  (<> [(file-to-module "rad/prelude/test-eval.rad")
+       '(import prelude/test-eval '[eval tests] :unqualified)]
       (map file-to-module pure-prelude-files)))
 
 (def send-prelude!

--- a/rad/prelude/test-eval.rad
+++ b/rad/prelude/test-eval.rad
@@ -1,0 +1,58 @@
+{:module 'prelude/test-eval
+ :doc
+   "Provides eval that adds a `:test` macro. If an the eval encounters an
+   expression of the form `(:test \"desc\" tests...)` we add it to the vector
+   stored in the `tests` ref. The tests are then run by `rad/prelude/test.rad`."
+ :exports '[eval tests]}
+
+(def tests
+  "Reference that collects tests defined with the `:test` macro. This
+  value is updated by a custom `eval`."
+  (ref []))
+
+;; Annoyingly verbose since we have neither the prelude nor pattern-matching.
+(def eval
+  "Evaluation function that adds :test macro to register tests."
+  (fn [expr env]
+    (if (list? expr)
+        (if (eq? (head expr) :test)
+            (do
+                (def bindings (lookup :env env))
+                (def test-def {:tests (drop 2 expr) :name (nth 1 expr) :env env})
+                (def next-tests {:val test-def})
+                (def bindings_ (insert 'next-tests__ next-tests bindings))
+                (def env (insert :env bindings_ env))
+                (eval '(do
+                  (write-ref tests (add-right next-tests__ (read-ref tests)))
+                  :nil
+                ) env))
+            (eval expr env))
+        (eval expr env))))
+
+(:test "'test' works (including :setup)"
+    [:setup
+       (do
+          (def x 3)
+          (def y (ref 0))
+          (write-ref y 1)
+          ;; Test the mocked send!/receive!
+          (def chain-name (uuid!))
+          (send! chain-name [0])
+          (def received (receive! chain-name 0)))
+    ]
+    [(+ 3 2) ==> 5]
+    [x       ==> 3]
+    [(read-ref y) ==> 1]
+    [received ==> (0)]
+)
+
+(:test "'test' handles exceptions properly"
+    [:setup
+      (do
+        (def x (catch 'any (throw 'blah) (fn [x] #t)))
+        (def y (catch 'any (throw 'blah) (fn [x] #f)))
+      )
+    ]
+    [x ==> #t]
+    [y ==> #f]
+)

--- a/rad/prelude/test.rad
+++ b/rad/prelude/test.rad
@@ -1,77 +1,51 @@
 {:module 'prelude/test
- :doc "An eval used for testing."
- :exports ['eval]}
+ :doc "Provides eval that adds a `:test` macro."
+ :exports '[run run-all]}
 
-;; testing functions
+(def run
+  "Run the tests in `test-def` and print the result. `test-def` is a `{:env env
+  :tests tests :name name}` dictionary where `env` is a radicle environment and
+  `tests` is a list of quoted test cases with an optional `:setup` item.
+  ```
+  '(
+    [:setup (do
+      (def foo #t)
+    )]
+    [ foo ==> #t ]
+    [ (not foo) ==> #f ]
+  )
+  ```
+  "
+  (fn [test-def]
+    (def test-env (lookup :env test-def))
+    (def test-name (lookup :name test-def))
+    (def error
+      (fn [msg]
+        (put-str! (string-append "Test '" test-name "' failed: " msg))))
+    ;; Check a single test in a given env
+    (def check-single
+      (fn [single ix senv]
+        (def lhs (nth 0 single))
+        (def marker (nth 1 single))
+        (def rhs (nth 2 single))
+        (if (eq? marker '==>)
+            (do
+              (def lhs-res (head (eval lhs senv)))
+              (if (eq? lhs-res rhs)
+                  (put-str! (string-append "Test '" test-name " (" (show ix) ")' succeeded"))
+                  (error (string-append "failed: got " (show lhs-res) " but expected " (show rhs)))))
+            (error "Expected and actual not separate by ==>"))
+        (+ ix 1)))
+    (def test-contents (lookup :tests test-def))
+    (def maybe-setup (nth 0 test-contents))
+    ;; If first block starts with :setup, run tests in that env
+    (if (eq? (nth 0 maybe-setup) :setup)
+        (do (def setup-env (nth 1 (eval (nth 1 maybe-setup) test-env)))
+            (foldl (fn [ix x] (check-single x ix setup-env)) 1 (tail test-contents)))
+        (foldl (fn [ix x] (check-single x ix test-env)) 1 test-contents))
+))
 
-(def is-test-env
-  "True iff file is being run as part of the Haskell suite"
-  (catch 'any (eq? test-env__ #t) (fn [x] #f)))
-
-;; Annoyingly verbose since we have neither the prelude nor pattern-matching.
-(def eval
-  "The evaluation function."
-  (fn [expr env]
-    (if (list? expr)
-        (if (> (foldr (fn [x acc] (+ acc 1)) 0 expr) 0)
-            (if (eq? (head expr) :test)
-                (if is-test-env
-                  (do
-                    (def test-name (nth 1 expr))
-                    (def error
-                      (fn [msg]
-                        (put-str! (string-append "Test '" test-name "' failed: " msg))))
-                    ;; Check a single test in a given env
-                    (def check-single
-                      (fn [single ix senv]
-                        (def lhs (nth 0 single))
-                        (def marker (nth 1 single))
-                        (def rhs (nth 2 single))
-                        (if (eq? marker '==>)
-                            (do
-                              (def lhs-res (head (eval lhs senv)))
-                              (if (eq? lhs-res rhs)
-                                  (put-str! (string-append "Test '" test-name " (" (show ix) ")' succeeded"))
-                                  (error (string-append "failed: got " (show lhs-res) " but expected " (show rhs)))))
-                            (error "Expected and actual not separate by ==>"))
-                        (+ ix 1)))
-                    (def test-contents (drop 2 expr))
-                    (def maybe-setup (nth 0 test-contents))
-                    ;; If first block starts with :setup, run tests in that env
-                    (if (eq? (nth 0 maybe-setup) :setup)
-                        (do (def setup-env (nth 1 (eval (nth 1 maybe-setup) env)))
-                            (foldl (fn [ix x] (check-single x ix setup-env)) 1 (tail test-contents)))
-                        (foldl (fn [ix x] (check-single x ix env)) 1 test-contents))
-                    (list :ok env))
-                  (list :ok env))
-                (eval expr env))
-            (eval expr env))
-        (eval expr env))))
-
-(:test "'test' works (including :setup)"
-    [:setup
-       (do
-          (def x 3)
-          (def y (ref 0))
-          (write-ref y 1)
-          ;; Test the mocked send!/receive!
-          (def chain-name (uuid!))
-          (send! chain-name [0])
-          (def received (receive! chain-name 0)))
-    ]
-    [(+ 3 2) ==> 5]
-    [x       ==> 3]
-    [(read-ref y) ==> 1]
-    [received ==> (0)]
-)
-
-(:test "'test' handles exceptions properly"
-    [:setup
-      (do
-        (def x (catch 'any (throw 'blah) (fn [x] #t)))
-        (def y (catch 'any (throw 'blah) (fn [x] #f)))
-      )
-    ]
-    [x ==> #t]
-    [y ==> #f]
-)
+(def run-all
+  "Run all `tests`."
+  (fn [tests]
+    (map (fn [t] (run t)) tests)))


### PR DESCRIPTION
We change how the `:test` macro is implemented. Instead of running a test immediately when it is encountered we register it in the environment and provide the `run-all-tests` function. The Haskell tests then call the functions.