### PR TITLE
Change storage interface 'receive' to return value list

### DIFF
--- a/exe/Server.hs
+++ b/exe/Server.hs
@@ -131,8 +131,8 @@ submit conn chains name (Values vals) = do
 
 
 -- | Get all expressions submitted to a chain since 'index'.
-since :: Connection -> Text -> Int -> Handler Value
-since conn name index = liftIO $ List <$> getSinceDB conn name index
+since :: Connection -> Text -> Int -> Handler Values
+since conn name index = liftIO $ Values <$> getSinceDB conn name index
 
 jsonOutputs :: Chains -> Text -> Handler [Maybe A.Value]
 jsonOutputs st name = do

--- a/src/Radicle/Internal/HttpStorage.hs
+++ b/src/Radicle/Internal/HttpStorage.hs
@@ -68,7 +68,7 @@ chainSubmitEndpoint = Proxy
 
 -- | Endpoint to obtain all entries in a chain starting from the given
 -- index. Responds with a Radicle vector of the expressions.
-type ChainSinceEndpoint = "since" :> Capture "index" Int :> Get '[PlainText] Value
+type ChainSinceEndpoint = "since" :> Capture "index" Int :> Get '[PlainText] Values
 
 chainSinceEndpoint :: Proxy ChainSinceEndpoint
 chainSinceEndpoint = Proxy
@@ -111,8 +111,8 @@ httpStoragePrimFns' mgr =
 submit :: [Value] -> ClientM Value
 submit = client chainSubmitEndpoint . Values
 
-since :: Int -> ClientM Value
-since = client chainSinceEndpoint
+since :: Int -> ClientM [Value]
+since idx = getValues <$> client chainSinceEndpoint idx
 
 runClientM' :: (MonadIO m) => Text -> HttpClient.Manager -> ClientM a -> m (Either ServantError a)
 runClientM' baseUrl manager endpoint = liftIO $ do

--- a/src/Radicle/Internal/Storage.hs
+++ b/src/Radicle/Internal/Storage.hs
@@ -38,7 +38,7 @@ type StorageSend m = Text -> Seq Value -> m (Either Text ())
 -- | Receive a list of expressions from a chain. The chain is identified by the first
 -- argument. The second argument is the index from which to start.
 -- Morally this is @'Data.List.drop' index chain@.
-type StorageReceive m = Text -> Int -> m (Either Text Value)
+type StorageReceive m = Text -> Int -> m (Either Text [Value])
 
 buildStoragePrimFns :: Monad m => StorageBackend m -> PrimFns m
 buildStoragePrimFns backend =
@@ -73,7 +73,7 @@ buildStoragePrimFns backend =
                       case res of
                           Left err -> throwErrorHere . OtherError
                                     $ receiveName <> ": request failed: " <> show err
-                          Right v' -> pure v'
+                          Right v' -> pure $ List v'
           (String _, v) -> throwErrorHere $ TypeError receiveName 1 TNumber v
           (v, _)        -> throwErrorHere $ TypeError receiveName 0 TString v
       )

--- a/test/spec/Radicle/Internal/TestCapabilities.hs
+++ b/test/spec/Radicle/Internal/TestCapabilities.hs
@@ -132,7 +132,7 @@ storagePrimFns =
                 let exprs = case Map.lookup id chains of
                         Nothing  -> []
                         Just res -> toList $ Seq.drop index res
-                pure $ Right $ List exprs
+                pure $ Right exprs
             )
         }
 


### PR DESCRIPTION
We change the `StorageReceive` signature to return a list of `Value`s instead of a value that had to be a Radicle list.

This gives us more type safety and requires less conversion in the storage implementations