### PR TITLE
Faster builds for `radicle-server` image

### DIFF
--- a/images/radicle-server/build.sh
+++ b/images/radicle-server/build.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 image_root=$(dirname $0)
 
 echo "Building radicle-server in container"
-stack build --docker
+stack build --docker :radicle-server
 
 bin_path=$(stack exec --docker -- which radicle-server)
 


### PR DESCRIPTION
We only build the `radicle-server` stack target when building the `radicle-server` image.