### PR TITLE
Use backticks for arguments in documentation

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -28,7 +28,7 @@ Returns ``y`` if ``x`` is not ``#f``, otherwise returns ``x``
 ``(or x y)``
 ~~~~~~~~~~~~
 
-Returns 'arg1' if 'arg1' is not #f, otherwise returns 'arg2'
+Returns ``x`` if ``x`` is not ``#f``, otherwise returns ``y``
 
 ``(all xs)``
 ~~~~~~~~~~~~
@@ -218,10 +218,10 @@ an exception.
 Given a non-empty sequence, returns the sequence of all the elements but
 the first. If the sequence is empty, throws an exception.
 
-``(empty? ls)``
-~~~~~~~~~~~~~~~
+``(empty? seq)``
+~~~~~~~~~~~~~~~~
 
-True if 'seq' is empty, false otherwise.
+True if ``seq`` is empty, false otherwise.
 
 ``cons``
 ~~~~~~~~
@@ -231,27 +231,27 @@ Adds an element to the front of a list.
 ``(reverse ls)``
 ~~~~~~~~~~~~~~~~
 
-Returns the reversed 'ls'.
+Returns the reversed list ``ls``.
 
 ``(length xs)``
 ~~~~~~~~~~~~~~~
 
-Returns the length of 'list'.
+Returns the length of ``xs``.
 
 ``(concat list1 list2)``
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Concatenates 'list1' and 'list2'.
+Concatenates ``list1`` and ``list2``.
 
 ``(filter pred ls)``
 ~~~~~~~~~~~~~~~~~~~~
 
-Returns 'list' with only the elements that satisfy 'filter-cond'.
+Returns ``ls`` with only the elements that satisfy ``pred``.
 
 ``(range from to)``
 ~~~~~~~~~~~~~~~~~~~
 
-Returns a list with all integers from ``from`` to ``end``, inclusive.
+Returns a list with all integers from ``from`` to ``to``, inclusive.
 
 ``(list-with-head x f g)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -289,7 +289,7 @@ Functions for manipulating boths lists and vectors.
 ``(empty-seq? xs)``
 ~~~~~~~~~~~~~~~~~~~
 
-Returns true if the input is an empty sequence (either list or vector).
+Returns true if ``xs`` is an empty sequence (either list or vector).
 
 ``nth``
 ~~~~~~~
@@ -397,18 +397,18 @@ Creates a dictionary from a list of key-value pairs.
 ``(keys d)``
 ~~~~~~~~~~~~
 
-Given a ``dict``, returns a vector of its keys.
+Given a dict ``d``, returns a vector of its keys.
 
 ``(values d)``
 ~~~~~~~~~~~~~~
 
-Given a ``dict``, returns a vector of its values.
+Given a dict ``d``, returns a vector of its values.
 
-``(rekey old-key new-key mp)``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``(rekey old-key new-key d)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Change the key from 'old-key' to 'new-key' in 'dict'. If 'new-key'
-already exists, it is overwritten.
+Change the key from ``old-key`` to ``new-key`` in a dict ``d``. If
+``new-key`` already exists, it is overwritten.
 
 ``map-values``
 ~~~~~~~~~~~~~~
@@ -423,22 +423,22 @@ Given a function ``f`` and a dict ``d``, returns a dict with the same
 values as ``d`` but ``f`` applied to all the keys. If ``f`` maps two
 keys to the same thing, the greatest key and value are kept.
 
-``(modify-map key f mp)``
-~~~~~~~~~~~~~~~~~~~~~~~~~
+``(modify-map k f d)``
+~~~~~~~~~~~~~~~~~~~~~~
 
-Given a key, a function and a dict, applies the function to the value
-associated to that key.
+Given a key ``k``, a function ``f`` and a dict ``d``, applies the
+function to the value associated to that key.
 
 ``(delete-many ks d)``
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Delete several keys from a dict.
+Delete several keys ``ks`` from a dict ``d``.
 
 ``(exclusive-dict-merge m n)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Merges two dicts while checking for key conflicts. Returns
-``{:merge   m :conflicts c}`` where ``m`` is the merged dict for all
+``{:merge m :conflicts c}`` where ``m`` is the merged dict for all
 non-conflicting keys and ``c`` is a dict with all the conflicting keys,
 mapping to pairs of values, one from each input dict.
 
@@ -596,7 +596,7 @@ Given a reference ``r`` and a value ``v``, updates the value stored in
 ``(modify-ref r f)``
 ~~~~~~~~~~~~~~~~~~~~
 
-Modify 'ref' by applying the provided function. Returns the new value.
+Modify ``r`` by applying the function ``f``. Returns the new value.
 
 Evaluation functions
 --------------------
@@ -682,7 +682,7 @@ Replaces the radicle state with the one provided.
 ~~~~~~~~~~~~
 
 Given an atom ``x`` and a value ``v``, sets the value associated to
-``x`` in the current environemtn to be ``v``. Doesn't evaluate ``v``.
+``x`` in the current environment to be ``v``. Doesn't evaluate ``v``.
 
 Input/Output
 ------------
@@ -729,9 +729,9 @@ Prints a string.
 ``(process! command args to-write)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Executes ``command`` using 'execvp'. with 'to-write' as input. Stdout
-and stderr are inherit. See 'man exec' for more information on 'execvp'.
-Example: ``(process! "ls" ["-Glah"] "")``.
+Executes ``command`` using ``execvp`` with ``to-write`` as input. Stdout
+and stderr are inherit. See ``man exec`` for more information on
+``execvp``. Example: ``(process! "ls" ["-Glah"] "")``.
 
 ``(shell! command to-write)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -817,8 +817,8 @@ Monadic bind for the maybe monad.
 ``(maybe-foldlM f i xs)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Monadic fold over the elements of a seq, associating to the left (i.e.
-from left to right) in the maybe monad.
+Monadic fold over the elements of a sequence ``xs``, associating to the
+left (i.e. from left to right) in the maybe monad.
 
 Lenses
 ------
@@ -848,7 +848,7 @@ View a value through a lens.
 ``(view-ref r lens)``
 ~~~~~~~~~~~~~~~~~~~~~
 
-Like 'view', but for refs.
+Like ``view``, but for refs.
 
 ``(set lens new-view target)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -858,7 +858,7 @@ Set a value though a lens.
 ``(set-ref r lens v)``
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Like 'set', but for refs.
+Like ``set``, but for refs.
 
 ``(over lens f target)``
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -868,7 +868,7 @@ Modify a value through a lens.
 ``(over-ref r lens f)``
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Like 'over', but for refs.
+Like ``over``, but for refs.
 
 ``id-lens``
 ~~~~~~~~~~~
@@ -1011,14 +1011,14 @@ A lens for variables in states of chains.
 ``(eval-in-chain expr chain)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Evaluates 'expr' in the 'chain' and returns a dict with the ':result'
-and the resulting ':chain'.
+Evaluates ``expr`` in the ``chain`` and returns a dict with the
+``:result`` and the resulting ``:chain``.
 
 ``(enter-remote-chain! url env)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Make the eval behave as that of a remote chain. The second param is the
-env to return to after :quit.
+env to return to after ``:quit``.
 
 ``(update-chain! chain)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/rad/chain.rad
+++ b/rad/chain.rad
@@ -21,7 +21,7 @@
 ;; eval-in-chain
 
 (def eval-in-chain
-  "Evaluates 'expr' in the 'chain' and returns a dict with the ':result' and the resulting ':chain'."
+  "Evaluates `expr` in the `chain` and returns a dict with the `:result` and the resulting `:chain`."
   (fn [expr chain]
     (def chain-eval (view (.. (@ :state) (@var 'eval)) chain))
     (def x (chain-eval expr (lookup :state chain)))
@@ -134,7 +134,7 @@
 
 ;; enter-remote-chain!
 (def enter-remote-chain!
-  "Make the eval behave as that of a remote chain. The second param is the env to return to after :quit."
+  "Make the eval behave as that of a remote chain. The second param is the env to return to after `:quit`."
   (fn [url env]
     (def chain (load-chain! url))
     (def chain-state (lookup :state chain))

--- a/rad/prelude/basic.rad
+++ b/rad/prelude/basic.rad
@@ -1,7 +1,7 @@
 ;; or
 
 (def or
-  "Returns 'arg1' if 'arg1' is not #f, otherwise returns 'arg2'"
+  "Returns `x` if `x` is not `#f`, otherwise returns `y`"
   (fn [x y]
     (if x x y)))
 
@@ -28,7 +28,7 @@
        )
 
 (def empty-seq?
-  "Returns true if the input is an empty sequence (either list or vector)."
+  "Returns true if `xs` is an empty sequence (either list or vector)."
   (fn [xs]
     (or (eq? xs (list))
         (eq? xs []))))
@@ -36,7 +36,7 @@
 ;; length
 
 (def length
-  "Returns the length of 'list'."
+  "Returns the length of `xs`."
   (fn [xs]
     (foldr (fn [x acc] (+ acc 1)) 0 xs)))
 

--- a/rad/prelude/dict.rad
+++ b/rad/prelude/dict.rad
@@ -14,7 +14,7 @@
 ;; keys
 
 (def keys
-  "Given a `dict`, returns a vector of its keys."
+  "Given a dict `d`, returns a vector of its keys."
   (fn [d]
     (map head (seq d))))
 
@@ -23,7 +23,7 @@
 )
 
 (def values
-  "Given a `dict`, returns a vector of its values."
+  "Given a dict `d`, returns a vector of its values."
   (fn [d]
     (map (fn [x] (nth 1 x)) (seq d))))
 
@@ -33,25 +33,25 @@
 
 ;; rekey
 (def rekey
-  "Change the key from 'old-key' to 'new-key' in 'dict'. If 'new-key' already exists, it is overwritten."
-  (fn [old-key new-key mp]
-    (def old-val (lookup old-key mp))
-    (delete old-key (insert new-key old-val mp))))
+  "Change the key from `old-key` to `new-key` in a dict `d`. If `new-key` already exists, it is overwritten."
+  (fn [old-key new-key d]
+    (def old-val (lookup old-key d))
+    (delete old-key (insert new-key old-val d))))
 
 (:test "rekey"
   [ (rekey :a :b {:a 5}) ==> {:b 5} ])
 
 ;; modify-map
 (def modify-map
-  "Given a key, a function and a dict, applies the function to the value associated to that key."
-  (fn [key f mp]
-    (insert key (f (lookup key mp)) mp)))
+  "Given a key `k`, a function `f` and a dict `d`, applies the function to the value associated to that key."
+  (fn [k f d]
+    (insert k (f (lookup k d)) d)))
 
 (:test "modify-map"
   [ (modify-map :a (fn [x] (+ x 1)) {:a 5})
      ==> {:a 6} ])
 
 (def delete-many
-  "Delete several keys from a dict."
+  "Delete several keys `ks` from a dict `d`."
   (fn [ks d]
     (foldr (fn [k d] (delete k d)) d ks)))

--- a/rad/prelude/io.rad
+++ b/rad/prelude/io.rad
@@ -39,8 +39,8 @@ Example: `(shell! \"ls -Glah\" \"\")`. "
       _ (throw 'io-error "expected only stdin to be open"))))
 
 (def process!
-  "Executes `command` using 'execvp'. with 'to-write' as input. Stdout and stderr are inherit.
-See 'man exec' for more information on 'execvp'.
+  "Executes `command` using `execvp` with `to-write` as input. Stdout and stderr are inherit.
+See `man exec` for more information on `execvp`.
 Example: `(process! \"ls\" [\"-Glah\"] \"\")`. "
   (fn [command args to-write]
     (def cp

--- a/rad/prelude/lens.rad
+++ b/rad/prelude/lens.rad
@@ -100,7 +100,7 @@
 
 ;; view-ref
 (def view-ref
-  "Like 'view', but for refs."
+  "Like `view`, but for refs."
   (fn [r lens]
     (view lens (read-ref r))))
 
@@ -110,7 +110,7 @@
 ;; set-ref
 
 (def set-ref
-  "Like 'set', but for refs."
+  "Like `set`, but for refs."
   (fn [r lens v]
     (modify-ref r (fn [x] (set lens v x)))))
 
@@ -124,7 +124,7 @@
 ;; over-ref
 
 (def over-ref
-  "Like 'over', but for refs."
+  "Like `over`, but for refs."
   (fn [r lens f]
     (modify-ref r (fn [x] (over lens f x)))))
 

--- a/rad/prelude/list.rad
+++ b/rad/prelude/list.rad
@@ -7,8 +7,8 @@
 ;; empty?
 
 (def empty?
-  "True if 'seq' is empty, false otherwise."
-  (fn [ls] (or (eq? ls nil) (eq? ls []))))
+  "True if `seq` is empty, false otherwise."
+  (fn [seq] (or (eq? seq nil) (eq? seq []))))
 
 (:test "empty"
   [ (empty? (list 2)) ==> #f ]
@@ -19,7 +19,7 @@
 ;; reverse
 
 (def reverse
-  "Returns the reversed 'ls'."
+  "Returns the reversed list `ls`."
   (fn [ls]
     (def-rec go
       (fn [acc new]
@@ -35,7 +35,7 @@
 ;; range
 
 (def-rec range
-  "Returns a list with all integers from `from` to `end`, inclusive."
+  "Returns a list with all integers from `from` to `to`, inclusive."
   (fn [from to]
     (if (eq? from to)
         (list to)
@@ -48,7 +48,7 @@
 ;; concat
 
 (def concat
-  "Concatenates 'list1' and 'list2'."
+  "Concatenates `list1` and `list2`."
   (fn [list1 list2]
     (foldr (fn [a b] (cons a b)) list2 list1)))
 
@@ -59,7 +59,7 @@
 ;; filter
 
 (def-rec filter
-  "Returns 'list' with only the elements that satisfy 'filter-cond'."
+  "Returns `ls` with only the elements that satisfy `pred`."
     (fn [pred ls]
       (cond
         (empty? ls)      ls

--- a/rad/prelude/patterns.rad
+++ b/rad/prelude/patterns.rad
@@ -13,7 +13,7 @@
       :nothing)))
 
 (def-rec maybe-foldlM
-  "Monadic fold over the elements of a seq, associating to the left (i.e. from
+  "Monadic fold over the elements of a sequence `xs`, associating to the left (i.e. from
   left to right) in the maybe monad."
   (fn [f i xs]
     (if (empty-seq? xs)
@@ -22,10 +22,10 @@
                  (fn [b] (maybe-foldlM f b (drop 1 xs)))))))
 
 (def exclusive-dict-merge
-  "Merges two dicts while checking for key conflicts. Returns `{:merge
-  m :conflicts c}` where `m` is the merged dict for all non-conflicting keys and
-  `c` is a dict with all the conflicting keys, mapping to pairs of values, one
-  from each input dict."
+  "Merges two dicts while checking for key conflicts. Returns
+  `{:merge m :conflicts c}` where `m` is the merged dict for all non-conflicting
+  keys and `c` is a dict with all the conflicting keys, mapping to pairs of
+  values, one from each input dict."
   (fn [m n]
     (foldr (fn [kv acc]
              (def k (nth 0 kv))

--- a/rad/prelude/ref.rad
+++ b/rad/prelude/ref.rad
@@ -2,6 +2,6 @@
 
 ;; modify-ref
 (def modify-ref
-  "Modify 'ref' by applying the provided function. Returns the new value."
+  "Modify `r` by applying the function `f`. Returns the new value."
   (fn [r f]
     (write-ref r (f (read-ref r)))))

--- a/src/Radicle/Internal/Effects.hs
+++ b/src/Radicle/Internal/Effects.hs
@@ -109,7 +109,7 @@ replPrimFns = fromList $ allDocs $
 
     , ( "set-env!"
       , "Given an atom `x` and a value `v`, sets the value associated to `x` in\
-        \ the current environemtn to be `v`. Doesn't evaluate `v`."
+        \ the current environment to be `v`. Doesn't evaluate `v`."
       , \case
         [Atom x, v] -> do
             defineAtom x Nothing v


### PR DESCRIPTION
Use backticks for arguments for better markdown in the documentation.
Adjust the argument names used in the documentation to reflect those used in the function.