### PR TITLE
Make stack use system GHC on CI

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,6 +20,9 @@ steps:
     - |
       set -euxo pipefail
 
+      stack config set system-ghc --global true
+      stack config set install-ghc --global false
+
       stack install stylish-haskell hlint weeder
 
   - id: "Format"


### PR DESCRIPTION
We force stack to use GHC from the `haskell:8.4.3`. This was accidently removed in #259.