### PR TITLE
Implement words and lines

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -558,6 +558,11 @@ Monadic bind for the maybe monad.
 Monadic fold over the elements of a seq, associating to the left (i.e.
 from left to right) in the maybe monad.
 
+``(elem? x xs)``
+~~~~~~~~~~~~~~~~
+
+Returns true if ``x`` is an element of the sequence ``xs``
+
 ``prelude/patterns``
 --------------------
 
@@ -626,6 +631,22 @@ Concatenate a list of strings, with newlines in between.
 ~~~~~~~~~~~~~~~
 
 Concatenate a list of strings, with spaces in between.
+
+``(split-by splitter? xs)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Splits a string ``xs`` into a list of strings whenever the function
+``splitter?`` returns true for a character.
+
+``(words xs)``
+~~~~~~~~~~~~~~
+
+Splits a string ``xs`` into a list of strings by whitespace characters.
+
+``(lines xs)``
+~~~~~~~~~~~~~~
+
+Splits a string ``xs`` into a list of strings by linebreaks.
 
 ``prelude/io``
 --------------

--- a/rad/prelude/basic.rad
+++ b/rad/prelude/basic.rad
@@ -1,6 +1,6 @@
 {:module  'prelude/basic
  :doc     "Basic function used for checking equality, determining the type of a value, etc."
- :exports '[or some empty-seq? length maybe->>= maybe-foldlM]}
+ :exports '[or some empty-seq? length maybe->>= maybe-foldlM elem?]}
 
 ;; or
 
@@ -68,3 +68,15 @@
       [:just i]
       (maybe->>= (f i (nth 0 xs))
                  (fn [b] (maybe-foldlM f b (drop 1 xs)))))))
+
+;; elem?
+
+(def elem?
+ "Returns true if `x` is an element of the sequence `xs`"
+ (fn [x xs]
+   (some (map (fn [c] (eq? c x)) xs))))
+
+(:test "elem?"
+ [ (elem? "f" (list "f" "g" "h")) ==> #t]
+ [ (elem? "h" ["f" "g" "h"]) ==> #t]
+ [ (elem? "a" (list "f" "g" "h")) ==> #f])

--- a/rad/prelude/strings.rad
+++ b/rad/prelude/strings.rad
@@ -1,9 +1,10 @@
 {:module 'prelude/strings
  :doc    "String manipulation functions."
- :exports '[intercalate unlines unwords]
+ :exports '[intercalate unlines unwords split-by words lines]
  }
 
 (import prelude/basic :unqualified)
+(import prelude/patterns :unqualified)
 
 (def intercalate
   "Intercalates a string in a list of strings"
@@ -36,3 +37,71 @@
 (:test "unwords"
   [ (unwords ["hi" "there"]) ==> "hi there" ]
 )
+
+(def space-chars
+  "A list of all white space character."
+  [" " "\t" "\n"])
+
+(def is-space-char?
+  "Returns true if the character `x` is a space character `space-chars`."
+  (fn [x]
+    (elem? x space-chars)))
+
+(:test "is-space-char?"
+  [ (is-space-char? "s") ==> #f]
+  [ (is-space-char? "s ") ==> #f]
+  [ (is-space-char? " ") ==> #t]
+  [ (is-space-char? "\t") ==> #t]
+  [ (is-space-char? "\n") ==> #t])
+
+;; split-by
+
+(def split-by
+  "Splits a string `xs` into a list of strings whenever the function `splitter?`
+  returns true for a character."
+  (fn [splitter? xs]
+    (def f (fn [acc new-char]
+      (def ls (nth 0 acc))
+      (def current (nth 1 acc))
+      (if (splitter? new-char)
+          (if (eq? current "")
+              [ls ""]
+              [(add-right current ls) ""])
+          [ls (string-append current new-char)])))
+    (match (foldl-string f [[] ""] xs)
+      ['ls ""] ls
+      ['ls 'x] (add-right x ls))))
+
+(:test "split-by"
+  [ (split-by (fn [x] (eq? "b" x)) "foobar") ==> ["foo" "ar"]]
+  [ (split-by is-space-char? "foo bar") ==> ["foo" "bar"]])
+
+;; words
+
+(def words
+  "Splits a string `xs` into a list of strings by whitespace characters."
+  (fn [xs]
+    (split-by is-space-char? xs)))
+
+(:test "words"
+  [ (words "foo bar") ==> ["foo" "bar"]]
+  [ (words "foo bar\nfoo ") ==> ["foo" "bar" "foo"]]
+  [ (words "foo   bar") ==> ["foo" "bar"]]
+  [ (words "foo") ==> ["foo"]]
+  [ (words " \n \t") ==> []]
+  [ (words "") ==> []])
+
+
+;; lines
+
+(def lines
+  "Splits a string `xs` into a list of strings by linebreaks."
+  (fn [xs]
+    (split-by (fn [x] (eq? "\n" x)) xs)))
+
+(:test "lines"
+  [ (lines "foo bar") ==> ["foo bar"]]
+  [ (lines "foo bar\nfoo ") ==> ["foo bar" "foo "]]
+  [ (lines "foo bar\n\n\nfoo") ==> ["foo bar" "foo"]]
+  [ (lines " \n \t") ==> [" " " \t"]]
+  [ (lines "") ==> []])


### PR DESCRIPTION
This solves part of #245 

To implement words and lines, `elem?` and `split-by` were implemented.