### PR TITLE
Parse doc strings as markdown blocks

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -475,7 +475,7 @@ right now, formatted according to ISO 8601.
 ~~~~~~~~~~~
 
 (system! proc) execute a system process. Returns the dict with the form
-``{ :stdin maybe-handle      :stdout maybe-handle      :stderr maybe-handle      :proc prochandle    }``
+``{ :stdin maybe-handle :stdout maybe-handle :stderr maybe-handle :proc prochandle }``
 Where ``maybe-handle`` is either ``[:just handle]`` or ``:nothing``.
 Note that this is quite a low-level function; higher-level ones are more
 convenient.


### PR DESCRIPTION
Radicle doc strings are parsed as markdown blocks.