### PR TITLE
Move counter app code into rad file

### DIFF
--- a/examples/radicle-counter
+++ b/examples/radicle-counter
@@ -60,35 +60,20 @@ fi
 case "$cmd" in
   init )
     radicle - <<-SCRIPT
-      (load! "rad/prelude.rad")
-      (send! "${chain}" '[
-        (def counter (ref 0))
-        (def increment
-          (fn []
-            (def x (read-ref counter))
-            (write-ref counter (+ x 1))))
-        (def get-value
-          (fn []
-            (read-ref counter)))
-      ])
-      :done
+      (load! "rad/examples/counter.rad")
+      (counter/init-chain! "${chain}")
 SCRIPT
     ;;
   get-value )
     radicle - <<-SCRIPT
-      (load! "rad/prelude.rad")
-      (def chain (load-chain! "${chain}"))
-      (lookup :result (eval-in-chain '(get-value) chain))
+      (load! "rad/examples/counter.rad")
+      (counter/get-value "${chain}")
 SCRIPT
     ;;
   increment )
     radicle - <<-SCRIPT
-      (load! "rad/prelude.rad")
-      (def chain (load-chain! "${chain}"))
-      (def expr '(increment))
-      (def result (lookup :result (eval-in-chain expr chain)))
-      (send! "${chain}" [expr])
-      result
+      (load! "rad/examples/counter.rad")
+      (counter/increment! "${chain}")
 SCRIPT
     ;;
   * )

--- a/rad/examples/counter.rad
+++ b/rad/examples/counter.rad
@@ -1,0 +1,64 @@
+;; A “counter” chain that exposes an `increment` mutator and a `get-value`
+;; accessor.
+;;
+;; This file provides functions to interact with a counter chain.
+;;
+;;     (counter/init-chain! "my-chain-id") ;; => :ok
+;;     (counter/get-value "my-chain-id") ;; => 0
+;;     (counter/increment! "my-chain-id") ;; => 1
+;;     (counter/get-value "my-chain-id") ;; => 1
+;;
+
+(load! "rad/prelude.rad")
+
+(import prelude/test '[assert-equal] :unqualified)
+
+(def counter/prelude
+  '[
+    (def counter (ref 0))
+    (def increment
+      "Increments the counter by one and returns the new counter."
+      (fn []
+        (def x (read-ref counter))
+        (write-ref counter (+ x 1))))
+    (def get-value
+      "Return the current value of the counter"
+      (fn []
+        (read-ref counter)))
+  ]
+)
+
+(def counter/init-chain!
+  "Send the counter application prelude to a chain."
+  (fn [chain-id]
+    (send! chain-id counter/prelude)
+    :done
+))
+
+(def counter/increment!
+  "Increment the counter of a chain and return the new counter value."
+  (fn [chain-id]
+    (def chain (chain/load-chain! chain-id))
+    (def expr '(increment))
+    (def result (lookup :result (chain/eval-in-chain expr chain)))
+    (send! chain-id [expr])
+    result
+))
+
+(def counter/get-value
+  "Get the current counter value of a chain."
+  (fn [chain-id]
+    (def chain (chain/load-chain! chain-id))
+    (lookup :result (chain/eval-in-chain '(get-value) chain))
+))
+
+(def counter/run-test
+  (fn []
+    (def chain-id (uuid!))
+    (assert-equal (counter/init-chain! chain-id) :done)
+    (assert-equal (counter/get-value chain-id) 0)
+    (assert-equal (counter/increment! chain-id) 1)
+    (assert-equal (counter/increment! chain-id) 2)
+    (assert-equal (counter/get-value chain-id) 2)
+    :test-ok
+) )

--- a/rad/prelude/test.rad
+++ b/rad/prelude/test.rad
@@ -1,6 +1,16 @@
 {:module 'prelude/test
  :doc "Provides eval that adds a `:test` macro."
- :exports '[run run-all]}
+ :exports '[run run-all assert-equal]}
+
+(def assert-equal
+  "Compares `actual` with `expected` with `eq?`. If the values are not equal an
+  `'assertion-error` is thrown. Otherwise `actual` is retuned."
+  (fn [actual expected]
+    (if (eq? actual expected)
+        actual
+        (throw 'assertion-error (string-append "failed: got " (show actual) " but expected " (show expected))))
+))
+
 
 (def run
   "Run the tests in `test-def` and print the result. `test-def` is a `{:env env

--- a/test/spec/Radicle/Internal/TestCapabilities.hs
+++ b/test/spec/Radicle/Internal/TestCapabilities.hs
@@ -6,6 +6,7 @@ module Radicle.Internal.TestCapabilities (
     , runPureCode
     , runCodeWithInput
     , runCodeWithFiles
+    , runCodeWithSourceFiles
 
     , WorldState(..)
     , defaultWorldState
@@ -81,6 +82,13 @@ runCodeWithFiles :: Map Text Text -> Text -> IO (Either (LangError Value) Value)
 runCodeWithFiles files code =
     let ws = defaultWorldState { worldStateFiles = files }
     in fst <$> runCodeWithWorld ws code
+
+-- | Run Radicle code in a REPL environment with all Radicle source files
+-- readable.
+runCodeWithSourceFiles :: Text -> IO (Either (LangError Value) Value)
+runCodeWithSourceFiles code = do
+    ws <- worldStateWithSource
+    fst <$> runCodeWithWorld ws code
 
 -- | Run radicle code in a pure environment.
 runPureCode :: Text -> Either (LangError Value) Value

--- a/test/spec/Radicle/Tests.hs
+++ b/test/spec/Radicle/Tests.hs
@@ -842,6 +842,11 @@ test_source_files = do
                     then pure ()
                     else assertFailure . toS $ "test failed: " <> line
 
+test_counter :: TestTree
+test_counter = testCase "rad/examples/counter.rad" $ do
+    res <- runCodeWithSourceFiles "(load! \"rad/examples/counter.rad\") (counter/run-test)"
+    res @?= Right (kw "test-ok")
+
 test_macros :: [TestTree]
 test_macros =
     [ testCase ":enter-chain keeps old bindings" $ do


### PR DESCRIPTION
We move the code for the counter example app from the Bash script to its own Radicle source file. We also provie tests for the counter app.