### PR TITLE
Make QuasiQuoters work properly

### DIFF
--- a/exe/GithubIssues.hs
+++ b/exe/GithubIssues.hs
@@ -14,6 +14,7 @@ import qualified GitHub.Endpoints.Issues.Comments as GH
 import           Options.Applicative
 
 import           Radicle
+import           Radicle.TH
 
 main :: IO ()
 main = do

--- a/exe/ReferenceDoc.hs
+++ b/exe/ReferenceDoc.hs
@@ -16,6 +16,7 @@ import qualified GHC.Exts as GhcExts
 import           Radicle
 import           Radicle.Internal.Core
 import           Radicle.Internal.Identifier
+import           Radicle.TH
 import           System.Console.Haskeline (defaultSettings, runInputT)
 import           Text.Pandoc
 

--- a/src/Radicle.hs
+++ b/src/Radicle.hs
@@ -46,8 +46,6 @@ module Radicle
     , throwErrorHere
     , Reference(..)
     , Ident
-    , ident
-    , kword
     , mkIdent
     , unsafeToIdent
     , fromIdent

--- a/src/Radicle/Internal.hs
+++ b/src/Radicle/Internal.hs
@@ -1,16 +1,7 @@
-{-# LANGUAGE TemplateHaskell #-}
 module Radicle.Internal
     ( module X
-    , mkIdent
-    , ident
-    , kword
     ) where
 
-import           Prelude (String)
-import           Protolude
-
-import           Language.Haskell.TH.Quote
-import qualified Language.Haskell.TH.Syntax as Syntax
 import           Radicle.Internal.Annotation as X
 import           Radicle.Internal.CLI as X
 import           Radicle.Internal.Core as X
@@ -21,34 +12,3 @@ import           Radicle.Internal.Parse as X
 import           Radicle.Internal.Pretty as X
 import           Radicle.Internal.PrimFns as X
 import           Radicle.Internal.Type as X
-
-import qualified Text.Megaparsec as M
-
--- | Smart constructor for Ident.
-mkIdent :: Text -> Maybe Ident
-mkIdent t = case runIdentity (M.runParserT valueP "" t) of
-    Right (Atom i) -> pure i
-    _              -> Nothing
-
-expQuot :: Text -> (String -> Syntax.Q Syntax.Exp) -> QuasiQuoter
-expQuot name e = QuasiQuoter
-    { quoteExp = e
-    , quoteType = panic err
-    , quotePat = panic err
-    , quoteDec = panic err
-    }
-  where
-    err = name <> " only works for expressions"
-
--- | A quasiquoter that checks that an identifier is valid at compile-time.
-ident :: QuasiQuoter
-ident =
-  expQuot "ident" $ \s -> [| case mkIdent s of
-    Nothing -> panic $ "Not a valid identifier: " <> s
-    Just i  -> i |]
-
-kword :: QuasiQuoter
-kword =
-  expQuot "kword" $ \s -> [| case mkIdent s of
-    Nothing -> panic $ "Not a valid keyword: " <> s
-    Just i  -> Keyword i |]

--- a/src/Radicle/Internal/Parse.hs
+++ b/src/Radicle/Internal/Parse.hs
@@ -168,3 +168,11 @@ parse file src = do
   case res of
     Left err -> throwError . toS $ M.parseErrorPretty' src err
     Right v  -> pure v
+
+-- | Smart constructor for Ident.
+mkIdent :: Text -> Maybe Ident
+mkIdent t = case runIdentity (M.runParserT (valueP <* M.eof) "" t) of
+    -- We use the 'valueP' parser instead of 'identP' so that we don’t
+    -- negative numbers  like @-4@.
+    Right (Atom i) -> pure i
+    _              -> Nothing

--- a/src/Radicle/TH.hs
+++ b/src/Radicle/TH.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Radicle.TH
+    ( ident
+    , kword
+    ) where
+
+import           Prelude (String)
+import           Protolude
+
+import qualified Data.Text as T
+import           Language.Haskell.TH.Quote
+import qualified Language.Haskell.TH.Syntax as Syntax
+
+import           Radicle.Internal.Core
+import           Radicle.Internal.Identifier
+import           Radicle.Internal.Parse (mkIdent)
+
+expQuot :: Text -> (String -> Syntax.Q Syntax.Exp) -> QuasiQuoter
+expQuot name e = QuasiQuoter
+    { quoteExp = e
+    , quoteType = panic err
+    , quotePat = panic err
+    , quoteDec = panic err
+    }
+  where
+    err = name <> " only works for expressions"
+
+-- | Checks wheter an identifier is valid at compile-time.
+-- @
+--     [ident|foo] :: Ident
+-- @
+ident :: QuasiQuoter
+ident =
+  expQuot "ident" $ \s -> case mkIdent (toS s) of
+    Nothing -> panic $ "Not a valid identifier: " <> toS s
+    Just _  -> [| Ident (T.pack s) |]
+
+-- | Produces a keyword 'Value'. Checks if the template is a valid
+-- keyword at compile-time. The template must not include the leading
+-- colon.
+-- @
+--     [kword|foo] :: Value
+-- @
+kword :: QuasiQuoter
+kword =
+  expQuot "kword" $ \s -> case mkIdent (toS s) of
+    Nothing -> panic $ "Not a valid keyword: " <> toS s
+    Just _  -> [| Keyword (Ident (T.pack s)) |]

--- a/test/spec/Radicle/Tests.hs
+++ b/test/spec/Radicle/Tests.hs
@@ -25,6 +25,7 @@ import           Radicle.Internal.Arbitrary ()
 import           Radicle.Internal.Core (asValue, noStack)
 import           Radicle.Internal.Foo (Foo)
 import           Radicle.Internal.TestCapabilities
+import           Radicle.TH
 
 test_eval :: [TestTree]
 test_eval =
@@ -592,6 +593,8 @@ test_parser =
         assertBool "not for -93G" (isNothing (mkIdent "-93G"))
         assertBool "not for +0X, no sir" (isNothing (mkIdent "+0X"))
         assertBool "5 is right out" (isNothing (mkIdent "5"))
+    , testCase "mkIdent does not accept whitespaces" $ do
+        assertBool "not for -93G" (isNothing (mkIdent "a b"))
     ]
   where
     x ~~> y = parseTest x @?= Right y


### PR DESCRIPTION
The quasi quoters `ident` and `kword` now throw, as advertised, at compile time. They also throw if there is a space in the identifier. We also move them into a separate module.