### PR TITLE
Better code and errors for reference docs

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -87,11 +87,6 @@ The default evaluation function. Expects an expression and a radicle
 state. Return a list of length 2 consisting of the result of the
 evaluation and the new state.
 
-``(eval expr env)``
-~~~~~~~~~~~~~~~~~~~
-
-Evaluation function that adds :test macro to register tests.
-
 ``ref``
 ~~~~~~~
 

--- a/package.yaml
+++ b/package.yaml
@@ -170,7 +170,6 @@ executables:
     - pandoc
     - data-default
     - containers
-    - haskeline
     - text
     - yaml
     ghc-options: -main-is ReferenceDoc

--- a/reference-doc.yaml
+++ b/reference-doc.yaml
@@ -30,7 +30,6 @@ primFns:
 - read-many
 # Eval
 - base-eval
-- eval
 # Refs
 - ref
 - read-ref


### PR DESCRIPTION
The code the generates the reference docs now
* provides better error messages
* and does not rely on hardcoded values in `checkAllInReference` anymore.

The `eval` documentation is now removed, which I think is ok given the fact that it only mentioned the `:test` macro.