### PR TITLE
Tag radicle-server images with commit sha

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,13 @@ rad> (fac 6)
 `radicle-server` is a service that hosts Radicle state machines and persists
 them to PostgreSQL.
 
-The lastest master build of this service is distributed as the Docker image
-`eu.gcr.io/opensourcecoin/radicle-server`. To build the image locally run
-`images/radicle-server/build.sh`. You can also use
-`images/radicle-server/docker-compose.yaml`.
+The latest master build of this service is distributed as the Docker image
+`eu.gcr.io/opensourcecoin/radicle-server:latest`. For every master commit we
+also provide an image tagged the current date and a short commit hash. For
+example `eu.gcr.io/opensourcecoin/radicle-server:b2018.12.06-a76a52f`.
+
+To build the image locally run `images/radicle-server/build.sh`. You can also
+use `images/radicle-server/docker-compose.yaml`.
 
 ## Development
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -46,7 +46,6 @@ steps:
 
       apt-get -qq update
       apt-get -yqq install libpq-dev
-      stack build --fast
       stack build --fast --test --no-terminal --pedantic
 
       ./images/radicle-server/ci-copy-bin.sh
@@ -81,6 +80,7 @@ steps:
     name: 'gcr.io/cloud-builders/docker'
     entrypoint: bash
     env:
+    - COMMIT_SHA=$COMMIT_SHA
     - BRANCH_NAME=$BRANCH_NAME
     args:
     - "-c"
@@ -89,11 +89,16 @@ steps:
 
       if [ "$BRANCH_NAME" == "master" ]; then
         image_name="eu.gcr.io/opensourcecoin/radicle-server"
+        short_sha=$(echo "$COMMIT_SHA" | head --bytes=7)
+        # Looks like this: b2018.12.06-a76a52f
+        tag="b$(date +%Y.%m.%d)-${short_sha}"
         docker build \
           --tag "$image_name" \
+          --tag "$image_name:$tag" \
           --cache-from "$image_name" \
           ./images/radicle-server
         docker push "$image_name"
+        docker push "$image_name:$tag"
       fi
 
   - id: "Save cache"


### PR DESCRIPTION
In addition to pushing the `radicle-server` image with the `latest` tag we push the same image with the date and short Git commit SHA as the tag. An example looks like this:

    b2018.12.06-a76a52f

This gives us both an indicator of then the image was build and what the commit SHA is.

We’ll use the image tags in https://github.com/oscoin/infrastructure/pull/2