### PR TITLE
Use localhost for chain tests

### DIFF
--- a/images/radicle-server/docker-compose.yaml
+++ b/images/radicle-server/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
     - --host=postgres
     - --db=postgres
     ports:
-    - "8024:8000"
+    - "8000:8000"
 
 volumes:
   pg-data: {}

--- a/rad/prelude/chain.rad
+++ b/rad/prelude/chain.rad
@@ -44,9 +44,12 @@
     {:chain new-chain
      :result result }))
 
+(def local-test-chain-name
+  (fn [] (string-append "http://localhost:8000/chains/" (uuid!))))
+
 (:test "eval-in-chain"
   [:setup
-    (do (def empty-chain (new-chain ""))
+    (do (def empty-chain (new-chain (local-test-chain-name)))
         (def res1 (eval-in-chain '(def x 3) empty-chain))
         (def res (eval-in-chain '(+ x 2) (lookup :chain res1))))
   ]
@@ -71,7 +74,7 @@
 (:test "update-chain!"
   [:setup
     (do
-       (def chain-name (uuid!))
+       (def chain-name (local-test-chain-name))
        (def chain (new-chain chain-name))
        (send! chain-name ['(+ 3 2)])
        (send! chain-name ['(+ 3 3)])
@@ -96,7 +99,7 @@
 (:test "update-chain-ref!"
   [:setup
     (do
-       (def chain-name (uuid!))
+       (def chain-name (local-test-chain-name))
        (def chain (ref (new-chain chain-name)))
        (send! chain-name ['(+ 3 2)])
        (send! chain-name ['(+ 3 3)])

--- a/rad/prelude/test-eval.rad
+++ b/rad/prelude/test-eval.rad
@@ -34,16 +34,10 @@
        (do
           (def x 3)
           (def y (ref 0))
-          (write-ref y 1)
-          ;; Test the mocked send!/receive!
-          (def chain-name (uuid!))
-          (send! chain-name [0])
-          (def received (receive! chain-name 0)))
+          (write-ref y 1))
     ]
     [(+ 3 2) ==> 5]
     [x       ==> 3]
-    [(read-ref y) ==> 1]
-    [received ==> (0)]
 )
 
 (:test "'test' handles exceptions properly"


### PR DESCRIPTION
Use localhost for chain tests so they can be run locally against `radicle-server`.