### PR TITLE
Cleaner filenames in stack trace

### DIFF
--- a/exe/RadicleExe.hs
+++ b/exe/RadicleExe.hs
@@ -18,7 +18,7 @@ main = do
         if sourceFile opts' == "-"
         then do
             src <- getContents
-            let prog = interpretMany (toS $ sourceFile opts') src
+            let prog = interpretMany "[stdin]" src
             bindings <- createBindings (toS <$> scriptArgs opts')
             (result, _state) <- runLang bindings prog
             case result of

--- a/src/Radicle/Internal/Effects.hs
+++ b/src/Radicle/Internal/Effects.hs
@@ -212,9 +212,7 @@ replPrimFns sysArgs = fromList $ allDocs $
       , oneArg "load!" $ \case
           String filename -> readFileS filename >>= \case
               Left err -> throwErrorHere . OtherError $ "Error reading file: " <> err
-              Right text -> interpretMany
-                  ("[load! " <> filename <> "]")
-                  (ignoreShebang text)
+              Right text -> interpretMany filename (ignoreShebang text)
           v -> throwErrorHere $ TypeError "load!" 0 TString v
       )
     , ( "gen-key-pair!"
@@ -335,7 +333,7 @@ replPrimFns sysArgs = fromList $ allDocs $
           String filename -> do
             t_ <- fmap ignoreShebang <$> readFileS filename
             t <- hoistEither . first (toLangError . OtherError) $ t_
-            vs <- readValues ("file-module!: " <> filename) t
+            vs <- readValues filename t
             createModule vs
           v -> throwErrorHere $ TypeError "file-module!" 0 TString v
       )

--- a/src/Radicle/Internal/PrimFns.hs
+++ b/src/Radicle/Internal/PrimFns.hs
@@ -85,13 +85,13 @@ purePrimFns = fromList $ allDocs $
     , ( "read"
       , "Parses a string into a radicle value. Does not evaluate the value."
       , oneArg "read" $ \case
-          String s -> readValue s
+          String s -> readValue "[read]" s
           v -> throwErrorHere $ TypeError "read" 0 TString v
       )
     , ( "read-many"
       , "Parses a string into a vector of radicle values. Does not evaluate the values."
       , oneArg "read-many" $ \case
-          String s -> Vec . Seq.fromList <$> readValues "read-many" s
+          String s -> Vec . Seq.fromList <$> readValues "[read-many]" s
           v -> throwErrorHere $ TypeError "read-many" 0 TString v
       )
     , ("get-current-env"
@@ -651,10 +651,10 @@ threeArg fname f = \case
 readValue
     :: (MonadError (LangError Value) m)
     => Text
+    -> Text
     -> m Value
-readValue s = do
-    let p = parse "[read-primop]" s
-    case p of
+readValue sourceFile code = do
+    case parse sourceFile code of
       Right v -> pure v
       Left e  -> throwErrorHere $ ThrownError (Ident "parse-error") (String e)
 
@@ -663,9 +663,8 @@ readValues
     => Text
     -> Text
     -> m [Value]
-readValues name s = do
-    let p = parseValues ("[" <> name <> "-primop]") s
-    case p of
+readValues sourceFile code = do
+    case parseValues sourceFile code  of
       Right vs -> pure vs
       Left e  -> throwErrorHere $ ThrownError (Ident "parse-error") (String . toS $ parseErrorPretty e)
 


### PR DESCRIPTION
We make the display of filenames cleaner in stack traces

* If the code comes from a file we only show the filename, not how the
  code was read
* If the code comes from another source we use the source name in
  brackets

Before

    [load!: rad/prelude/chain.rad-primop]:76:9
    [file-module!: rad/prelude/chain.rad-primop]:76:9
    [read-primop]:76:9
    -:76:9

Now

    Unknown identifier
      rad/prelude/chain.rad-primop:76:9
      rad/prelude/chain.rad-primop:76:9
      [read]:76:9
      [stdin]:76:9