### PR TITLE
Parametrized issues chain

### DIFF
--- a/bin/rad-issues
+++ b/bin/rad-issues
@@ -2,7 +2,10 @@
 
 (load! "rad/prelude.rad")
 
+(def base-name "http://machine.radicle.xyz/chains")
+
 (def help
+  (string-append
   "rad-issues - Radicle issue CLI
 
    Usage:
@@ -11,19 +14,29 @@
 
      list - Select from all issues to view or comment on
      new  - Create a new issue in $EDITOR
-     help - Print this help and exit")
+     help - Print this help and exit
 
-(def base-name "http://machine.radicle.xyz/chains")
+   If <chain-name> begins with 'http://', that URL will be used. Otherwise,
+  " base-name " will be prepended to <chain-name>." ))
+
+(def make-chain-ref
+  (fn [chain]
+    (def name
+      (if (eq? (take 7 chain) "http://")
+          chain
+          (string-append base-name chain)))
+    (ref (chain/load-chain! name))))
 
 (def list-issues
-  (fn []
+  (fn [chain]
+    (def chain-ref (make-chain-ref chain))
     (load! "rad/prelude/io-utils.rad")
     (load! "rad/monadic/issues.rad")
 
     (def mk-key (fn [v]
       (match v
         ['key 'val] [(string-append (show key) " - " (lookup :title val)) val])))
-    (def iss (dict-from-seq (map mk-key (seq (list-issues)))))
+    (def iss (dict-from-seq (map mk-key (seq (list-issues chain-ref)))))
     (def selected (fzf-select-by-key! iss))
     (def comment-divider "---")
     (def username
@@ -59,7 +72,8 @@
     (print! (send-comment edited-issue))))
 
 (def new-issue
-  (fn []
+  (fn [chain]
+    (def chain-ref (make-chain-ref chain))
     (load! "rad/prelude/io-utils.rad")
     (load! "rad/monadic/issues.rad")
     (def template
@@ -71,13 +85,14 @@
 ")
     (def iss (read (edit-in-editor! template)))
     (create-issue!
+         chain-ref
          (<> iss {:state :open :comments [] :created-at (now!)}))))
 
 (def args (get-args!))
 (match args
-  ["list"] (list-issues)
-  ["new" ] (new-issue)
-  ["help"] (put-str! help)
-  _        (do
-             (put-str! (string-append "Unrecognized command" (show args)))
-             (put-str! help)))
+  ["list" 'chain] (list-issues chain)
+  ["new"  'chain] (new-issue chain)
+  ["help"]        (put-str! help)
+  _               (do
+                    (put-str! (string-append "Unrecognized command" (show args)))
+                    (put-str! help)))

--- a/bin/rad-issues
+++ b/bin/rad-issues
@@ -4,7 +4,7 @@
 (load! "rad/monadic/issues.rad")
 (load! "rad/prelude/io-utils.rad")
 
-(def base-name "http://machine.radicle.xyz/chains")
+(def base-name "http://machines.radicle.xyz/chains/")
 
 (def help
   (string-append

--- a/bin/rad-issues
+++ b/bin/rad-issues
@@ -1,6 +1,8 @@
 #!/usr/bin/env radicle
 
 (load! "rad/prelude.rad")
+(load! "rad/monadic/issues.rad")
+(load! "rad/prelude/io-utils.rad")
 
 (def base-name "http://machine.radicle.xyz/chains")
 
@@ -9,29 +11,30 @@
   "rad-issues - Radicle issue CLI
 
    Usage:
-        rad [list|new] <chain-name>
-        rad help
+        rad-issues [list|new|create-chain] <chain-name>
+        rad-issues help
 
-     list - Select from all issues to view or comment on
-     new  - Create a new issue in $EDITOR
-     help - Print this help and exit
+     list         - Select from all issues to view or comment on
+     new          - Create a new issue in $EDITOR
+     create-chain - Create a new issues chain
+     help         - Print this help and exit
 
    If <chain-name> begins with 'http://', that URL will be used. Otherwise,
   " base-name " will be prepended to <chain-name>." ))
 
+(def make-name
+  (fn [chain]
+    (if (eq? (take 7 chain) "http://")
+        chain
+        (string-append base-name chain))))
+
 (def make-chain-ref
   (fn [chain]
-    (def name
-      (if (eq? (take 7 chain) "http://")
-          chain
-          (string-append base-name chain)))
-    (ref (chain/load-chain! name))))
+    (ref (chain/load-chain! (make-name chain)))))
 
 (def list-issues
   (fn [chain]
     (def chain-ref (make-chain-ref chain))
-    (load! "rad/prelude/io-utils.rad")
-    (load! "rad/monadic/issues.rad")
 
     (def mk-key (fn [v]
       (match v
@@ -88,11 +91,16 @@
          chain-ref
          (<> iss {:state :open :comments [] :created-at (now!)}))))
 
+(def create-chain
+  (fn [chain]
+    (create-issues-chain! (make-name chain))))
+
 (def args (get-args!))
 (match args
-  ["list" 'chain] (list-issues chain)
-  ["new"  'chain] (new-issue chain)
-  ["help"]        (put-str! help)
-  _               (do
-                    (put-str! (string-append "Unrecognized command" (show args)))
-                    (put-str! help)))
+  ["list" 'chain]         (list-issues chain)
+  ["new"  'chain]         (new-issue chain)
+  ["create-chain" 'chain] (create-chain chain)
+  ["help"]                (put-str! help)
+  _                       (do
+                            (put-str! (string-append "Unrecognized command" (show args)))
+                            (put-str! help)))

--- a/bin/rad-issues
+++ b/bin/rad-issues
@@ -70,9 +70,9 @@
         (def comment (extract-comment edited-issue))
         (if (eq? comment "")
           "Issue was not updated."
-          (do (simple-add-comment! (issue-number selected) comment)
+          (do (simple-add-comment! chain-ref (issue-number selected) comment)
             (string-append "Sent comment: " comment)))))
-    (print! (send-comment edited-issue))))
+    (put-str! (send-comment edited-issue))))
 
 (def new-issue
   (fn [chain]

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -13,14 +13,16 @@ in
 
 stdenv.mkDerivation {
     name = "radicle-dev";
-    buildInputs = [ ghc zlib python3 wget stack postgresql glibcLocales moreutils fzf]
+    buildInputs = [ ghc zlib glibcLocales python3 wget stack postgresql moreutils fzf]
       ++ (if doc then [docstuffs postgresql] else [])
       ++ (if extras then [ vimPlugins.stylish-haskell haskellPackages.apply-refact hlint ] else []);
+    LANG = "en_US.UTF-8";
     libraryPkgconfigDepends = [ zlib ];
     shellHook = ''
       export PATH=$PATH:`stack path --local-bin`
-      export STACK_ARGS="--system-ghc --nix-packages 'zlib fzf moreutils'"
+      export STACK_ARGS="--system-ghc --no-nix-pure --nix-packages 'zlib fzf moreutils'"
       export IS_NIX_SHELL="true"
+      export LOCALE_ARCHIVE="${pkgs.glibcLocales}/lib/locale/locale-archive";
       eval $(grep export ${ghc}/bin/ghc)
       alias check="pushd $PWD && ./scripts/check-fmt.sh && hlint . && popd"
       alias mkdocs="pushd $PWD/docs && make html && popd"

--- a/rad/monadic/issues.rad
+++ b/rad/monadic/issues.rad
@@ -17,8 +17,8 @@
 
 (def create-issues-chain!
   "Create a remote issue chain with the given url."
-  (fn []
-    (def url (lookup :url (read-ref issues-chain)))
+  (fn [chain]
+    (def url (lookup :url (read-ref chain)))
     (chain/send-prelude! url)
     (send-code! url "rad/monadic/issue-remote.rad")))
 
@@ -57,41 +57,41 @@
 
 (def create-issue!
   "Create a new remote issue with the keys in `my-keys.rad`."
-  (fn [i]
-    (send! (lookup :url (read-ref issues-chain))
+  (fn [chain i]
+    (send! (lookup :url (read-ref chain))
            [(list 'create-issue (sign-entity! i))])))
 
 (def add-comment!
   "Create a remote comment with the keys in `my-keys.rad`."
-  (fn [c]
-    (send! (lookup :url (read-ref issues-chain))
+  (fn [chain c]
+    (send! (lookup :url (read-ref chain))
            [(list 'add-comment (sign-entity! c))])))
 
 (def simple-create-issue!
   "Create a remote issue with sensible defaults."
-  (fn [tit bod]
-    (create-issue! (simple-issue tit bod))))
+  (fn [chain tit bod]
+    (create-issue! chain (simple-issue tit bod))))
 
 (def simple-add-comment!
   "Create a remote comment."
-  (fn [in b]
-    (add-comment! (simple-comment in b))))
+  (fn [chain in b]
+    (add-comment! chain (simple-comment in b))))
 
 (def list-issues
   "Return the full map of issues."
-  (fn []
-    (lookup :result (chain/eval-in-chain '(list-issues) (read-ref issues-chain)))))
+  (fn [chain]
+    (lookup :result (chain/eval-in-chain '(list-issues) (read-ref chain)))))
 
 (def fetch!
   "Update the locally cached state of the chain."
-  (fn []
-    (chain/update-chain-ref! issues-chain)))
+  (fn [chain]
+    (chain/update-chain-ref! chain)))
 
 (def import-github
   "Imports the github issues stored in file `githubissues.rad`. To create this
   file use the `radicle-github-issues` executable. Will add a note to all
   `:body`s that this is an imported entity."
-  (fn []
+  (fn [chain]
     (def note-imported
       (fn [x]
         (insert
@@ -109,7 +109,7 @@
       (map
        (fn [i] (note-imported (note-comments i)))
        issues))
-    (map create-issue! imported)))
+    (map (fn [i] (create-issue! chain i) imported))))
 
 (def short
   "Short render of an issue."
@@ -121,25 +121,25 @@
 
 (def list-last
   "Get the last `n` issues."
-  (fn [n]
-    (def is (sort-by (fn [i] (- 0 (lookup :number i))) (values (list-issues))))
+  (fn [chain n]
+    (def is (sort-by (fn [i] (- 0 (lookup :number i))) (values (list-issues chain))))
     (take n is)))
 
 (def get-by-id
   (fn [id]
-    (lookup id (list-issues))))
+    (lookup id (list-issues chain))))
 
 (:test
  "The monadic issues chain works."
  [:setup
-  (do (write-ref issues-chain (chain/new-chain "http://localhost:8024/chains/fxoo"))
-      (create-issues-chain!)
-      (simple-create-issue! "title0" "body0")
-      (simple-create-issue! "title1" "body1")
-      (simple-add-comment! 0 "comment0")
-      (simple-add-comment! 1 "comment1")
-      (fetch!)
-      (def is (list-issues)))]
+  (do (def chain (ref (chain/new-chain "http://localhost:8024/chains/fxoo")))
+      (create-issues-chain! chain)
+      (simple-create-issue! chain "title0" "body0")
+      (simple-create-issue! chain "title1" "body1")
+      (simple-add-comment! chain 0 "comment0")
+      (simple-add-comment! chain 1 "comment1")
+      (fetch! chain)
+      (def is (list-issues chain)))]
  [ (length (seq is)) ==> 2 ]
  [ (view (.. (@ 0) (@ :title)) is) ==> "title0" ]
  [ (view (.. (@ 1) (@ :title)) is) ==> "title1" ]

--- a/rad/monadic/issues.rad
+++ b/rad/monadic/issues.rad
@@ -131,8 +131,9 @@
 (:test
  "The monadic issues chain works."
  [:setup
-  (do (def chain (ref (chain/new-chain "http://localhost:8024/chains/fxoo")))
-      (create-issues-chain! chain)
+  (do (def chain-name "http://localhost:8024/chains/fxoo")
+      (def chain (ref (chain/new-chain chain-name)))
+      (create-issues-chain! chain-name)
       (simple-create-issue! chain "title0" "body0")
       (simple-create-issue! chain "title1" "body1")
       (simple-add-comment! chain 0 "comment0")
@@ -144,5 +145,5 @@
  [ (view (.. (@ 1) (@ :title)) is) ==> "title1" ]
  [ (view (... [(@ 1) (@ :comments) (@nth 0) (@ :body)]) is) ==> "comment1" ]
  [ (short (first (values is))) ==> "0: title0" ]
- [ (short (first (list-last 1))) ==> "1: title1" ]
+ [ (short (first (list-last chain 1))) ==> "1: title1" ]
 )

--- a/rad/monadic/issues.rad
+++ b/rad/monadic/issues.rad
@@ -17,8 +17,7 @@
 
 (def create-issues-chain!
   "Create a remote issue chain with the given url."
-  (fn [chain]
-    (def url (lookup :url (read-ref chain)))
+  (fn [url]
     (chain/send-prelude! url)
     (send-code! url "rad/monadic/issue-remote.rad")))
 

--- a/src/Radicle/Internal/PrimFns.hs
+++ b/src/Radicle/Internal/PrimFns.hs
@@ -190,6 +190,7 @@ purePrimFns = fromList $ allDocs $
             Right i -> case vs of
               List xs -> pure . List $ take i xs
               Vec xs  -> pure . Vec $ Seq.take i xs
+              String xs  -> pure . String $ T.take i xs
               _       -> throwErrorHere $ TypeError "take" 1 TSequence vs
           (v, _) -> throwErrorHere $ TypeError "take" 0 TNumber v
       )

--- a/src/Radicle/Internal/PrimFns.hs
+++ b/src/Radicle/Internal/PrimFns.hs
@@ -188,10 +188,10 @@ purePrimFns = fromList $ allDocs $
           (Number n, vs) -> case Num.isInt n of
             Left _ -> throwErrorHere $ OtherError "take: first argument must be an integer"
             Right i -> case vs of
-              List xs -> pure . List $ take i xs
-              Vec xs  -> pure . Vec $ Seq.take i xs
-              String xs  -> pure . String $ T.take i xs
-              _       -> throwErrorHere $ TypeError "take" 1 TSequence vs
+              List xs   -> pure . List $ take i xs
+              Vec xs    -> pure . Vec $ Seq.take i xs
+              String xs -> pure . String $ T.take i xs
+              _         -> throwErrorHere $ TypeError "take" 1 TSequence vs
           (v, _) -> throwErrorHere $ TypeError "take" 0 TNumber v
       )
     , ( "nth"


### PR DESCRIPTION
Parametrizes issues functions by chain. Adds the chain name to the CLI as an option. Also:

- Makes `take` work with strings
- Makes `issues.rad` not load the chain automatically on import/load.