### PR TITLE
Update script to run all CI tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,18 @@ example `eu.gcr.io/opensourcecoin/radicle-server:b2018.12.06-a76a52f`.
 To build the image locally run `images/radicle-server/build.sh`. You can also
 use `images/radicle-server/docker-compose.yaml`.
 
+## Issues
+
+We are currently using `radicle` itself to manage issues, and have therefore
+disabled issues on Github. You can create and see issues with the
+`bin/rad-issues` script. You can also reach us on the `radicle` IRC channel on
+`#freenode`.
+
 ## Development
 
-You can run tests with `stack test`.
+The script `./scripts/ci-tests.sh` runs all tests that are run on CI. The script
+requires [`docker`][docker] and [`docker-compose`][docker-compose] to be
+installed for end-to-end tests.
 
 The end-to-end test suite is run with `stack test :e2e`. It requires you to
 start up an IPFS test network with
@@ -58,9 +67,15 @@ The documentation is build with `make -C docs html`. Reference documentation for
 Radicle code must be regenerated with `stack run radicle-doc-ref` and checked
 into version control.
 
-## Issues
+### Troubleshooting
 
-We are currently using `radicle` itself to manage issues, and have therefore
-disabled issues on Github. You can create and see issues with the
-`bin/rad-issues` script. You can also reach us on the `radicle` IRC channel on
-`#freenode`.
+Your local machine might build binaries that are incompatible with the
+`debian:stretch` container image. In that case building the docker images fails.
+You can build compatible binaries using stack’s [docker
+integration][stack-docker-integration]. This is enabled by passing the
+`STACK_DOCKER=1` environment to `./scripts/ci-tests.sh`.
+
+
+[stack-docker-integration]: https://docs.haskellstack.org/en/stable/docker_integration/
+[docker]: https://www.docker.com/get-started
+[docker-compose]: https://docs.docker.com/compose/install

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -170,9 +170,11 @@ steps:
     - "-c"
     - |
       set -euxo pipefail
-      docker-compose -f test/docker-compose.yaml up -d postgres
+
+      export COMPOSE_FILE=test/docker-compose.yaml
+      docker-compose up -d postgres
       sleep 5 # Wait for the DB to be ready
-      docker-compose -f test/docker-compose.yaml up -d
+      docker-compose up -d
       sleep 3 # Wait for service to be booted
 
       # Connect services to 'cloudbuild' network so they can be

--- a/images/radicle-server/ci-copy-bin.sh
+++ b/images/radicle-server/ci-copy-bin.sh
@@ -2,9 +2,13 @@
 
 set -eo pipefail
 
-image_root=$(dirname $0)
+image_root=$(dirname $BASH_SOURCE)
 
-bin_path=$(stack exec -- which radicle-server)
+if [ "$STACK_DOCKER" = "1" ]; then
+  bin_path=$(stack exec --docker -- which radicle-server)
+else
+  bin_path=$(stack exec -- which radicle-server)
+fi
 
 mkdir -p "$image_root/bin"
 cp -a "$bin_path" "$image_root/bin"

--- a/scripts/ci-tests.sh
+++ b/scripts/ci-tests.sh
@@ -1,13 +1,48 @@
 #!/usr/bin/env bash
+#
+# Run all the tests that are run by CI.
+#
+# If STACK_DOCKER=1 is set all stack commands are executed with the
+# `--docker` flag. This ensures that the binaries built on the host
+# can run in the docker containers.
 
-# Run all the tests that are run by CI (but without using local docker because
-# how does a mortal even set that up!?)
+set -exuo pipefail
 
-set -e -x
-BASEDIR=$(dirname $BASH_SOURCE)/..
-cd $BASEDIR
-hothasktags -XLambdaCase -XTypeFamilies -XScopedTypeVariables -XFunctionalDependencies -XTupleSections -XExplicitNamespaces -XStandaloneDeriving -XDefaultSignatures -R src > TAGS
-stack exec hlint .
+stack_exe=$(which stack)
+
+cd $(dirname $BASH_SOURCE)/..
+
+# Wrapper for `stack` that sets the `--docker` flag when `STACK_DOCKER`
+# is set.
+function stack () {
+  if [[ "${STACK_DOCKER:-0}" =~ 1 ]]; then
+    $stack_exe --docker "$@"
+  else
+    $stack_exe "$@"
+  fi
+}
+
+stack build weeder hlint
+stack exec -- hlint .
 ./scripts/check-fmt.sh
-stack test --fast
-stack exec radicle-ref-doc
+
+stack build --fast --pedantic --test
+stack exec -- weeder --match
+
+./images/radicle-server/ci-copy-bin.sh
+
+export COMPOSE_FILE=test/docker-compose.yaml
+docker-compose up -d postgres
+sleep 5 # Wait for the DB to be ready
+docker-compose up -d
+sleep 3 # Wait for service to be booted
+
+echo '{"radicle": true}' | docker exec -i test_ipfs-test-network_1 ipfs dag put --pin
+
+export RAD_IPFS_API_URL=http://localhost:19301
+export RADPATH="$(pwd)/rad"
+stack test :e2e
+stack exec -- radicle test/machine-backends.rad localhost
+
+stack exec -- radicle-ref-doc
+stack exec -- radicle-doc docs/source/guide/Basics.lrad


### PR DESCRIPTION
We update `./scripts/ci-tests.sh` to reflect all the CI checks we are currently running. We also document the script in the README.

Note that we do require docker to make sure that the `radicle-server` binary that we build works in the image.