### PR TITLE
Generalization of the storage interface

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -143,7 +143,8 @@ steps:
     - "-c"
     - |
       set -euxo pipefail
-      stack exec radicle - <<<'(load! "rad/examples/counter.rad") (counter/run-test)'
+      stack exec -- radicle - <<<'(load! "rad/examples/counter.rad") (counter/run-test)'
+      stack exec -- radicle test/server.rad radicle-server
 
   - id: "Save cache"
     waitFor:

--- a/exe/Server/DB.hs
+++ b/exe/Server/DB.hs
@@ -19,8 +19,8 @@ insertExprDB conn name val
         <> "VALUES ((SELECT (COALESCE(MAX(id),-1) + 1) FROM txs WHERE chain = ?), ?, ?)"
 
 getSinceDB :: Connection -> Text -> Int -> IO [Value]
-getSinceDB conn name index
-    = query conn "SELECT expr FROM txs WHERE chain = ? AND id >= ? ORDER BY id ASC" (name, index)
+getSinceDB conn name id
+    = query conn "SELECT expr FROM txs WHERE chain = ? AND id >= ? ORDER BY id ASC" (name, id)
 
 -- | Get all txs in all chains. Useful after a server restart.
 getAllDB :: Connection -> IO [(Text, [Value])]

--- a/rad/prelude/chain.rad
+++ b/rad/prelude/chain.rad
@@ -24,7 +24,8 @@
   (fn [url]
     {:state (pure-env)
      :inputs []
-     :url url}))
+     :url url
+     :index :nothing}))
 
 ;; eval-in-chain
 
@@ -64,13 +65,16 @@
   "Takes a chain, and returns a new chain updated with the new expressions from the remote chain"
   (fn [chain]
     (def index (length (lookup :inputs chain)))
-    (def new-inputs
-      (receive! (lookup :url chain) index))
+    (def receive-result
+      (receive! (lookup :url chain) (lookup :index chain)))
+    (def new-index (nth 0 receive-result))
+    (def new-inputs (nth 1 receive-result))
     (def upd-ch
       (fn [ch expr]
         (def x (eval-in-chain expr ch))
         (view (@ :chain) x)))
-    (foldl upd-ch chain new-inputs)))
+    (def chain (foldl upd-ch chain new-inputs))
+    (insert :index [:just new-index] chain)))
 
 (:test "update-chain!"
   [:setup

--- a/src/Radicle/Internal/Storage.hs
+++ b/src/Radicle/Internal/Storage.hs
@@ -5,6 +5,9 @@
 -- A storage backend defines two functions 'StorageSend' and
 -- 'StorageReceive' explained below.
 --
+-- Storage backends use /indices/ to identify entries in a chain. These
+-- indices can be used like cursors in a database.
+--
 -- For usage examples see "Radicle.Internal.HttpStorage" and
 -- "Radicle.Internal.TestCapabilities".
 module Radicle.Internal.Storage
@@ -16,9 +19,8 @@ import           Protolude hiding (TypeError)
 
 import           GHC.Exts (fromList)
 
+import           Radicle.Internal.Annotation (WithPos)
 import           Radicle.Internal.Core
-import           Radicle.Internal.Identifier
-import qualified Radicle.Internal.Number as Num
 import qualified Radicle.Internal.PrimFns as PrimFns
 import           Radicle.Internal.Type
 
@@ -27,21 +29,30 @@ import           Radicle.Internal.Type
 --
 -- The first tuple item is the Radicle identifier the function will be
 -- exposed as. The second tuple item is documentation.
-data StorageBackend m = StorageBackend
-    { storageSend    :: (Text, Text, StorageSend m)
-    , storageReceive :: (Text, Text, StorageReceive m)
+data StorageBackend i m = StorageBackend
+    { storageSend    :: (Text, Text, StorageSend i m)
+    , storageReceive :: (Text, Text, StorageReceive i m)
     }
 
 -- | Send a list of expressions to a chain identified by the first
--- argument.
-type StorageSend m = Text -> Seq Value -> m (Either Text ())
+-- argument. Returns an error or the index of the expression that was
+-- sent.
+type StorageSend i m = Text -> Seq Value -> m (Either Text i)
 
--- | Receive a list of expressions from a chain. The chain is identified by the first
--- argument. The second argument is the index from which to start.
--- Morally this is @'Data.List.drop' index chain@.
-type StorageReceive m = Text -> Int -> m (Either Text [Value])
+-- | Receive all expressions following the given expression and a new
+-- index for further queries.
+--
+-- If second arugment is @'Just' i@ then we return all expressions that
+-- follow the expression index by @i@ and not including that
+-- expression.
+--
+-- If the second argument is 'Nothing' we return all expressions.
+--
+-- The first item in the tuple returned is the index of the last entry
+-- in the list of expressions returned.
+type StorageReceive i m = Text -> Maybe i -> m (Either Text (i, [Value]))
 
-buildStoragePrimFns :: Monad m => StorageBackend m -> PrimFns m
+buildStoragePrimFns :: forall i m. (Monad m, FromRad WithPos i, ToRad WithPos i) => StorageBackend i m -> PrimFns m
 buildStoragePrimFns backend =
     fromList . PrimFns.allDocs $ [sendPrimop, receivePrimop]
   where
@@ -54,7 +65,7 @@ buildStoragePrimFns backend =
              res <- lift $ send id v
              case res of
                  Left e  -> throwErrorHere (SendError e)
-                 Right _ -> pure $ Keyword $ unsafeToIdent "ok"
+                 Right r -> pure $ toRad r
          (String _, v) -> throwErrorHere $ TypeError sendName 1 TVec v
          (v, _) -> throwErrorHere $ TypeError sendName 0 TString v
       )
@@ -64,16 +75,17 @@ buildStoragePrimFns backend =
       ( receiveName
       , receiveDoc
       , PrimFns.twoArg receiveName $ \case
-          (String id, Number q) -> do
-              case Num.isInt q of
-                  Left _ -> throwErrorHere . OtherError
-                                     $ receiveName <> ": expecting int argument"
-                  Right n -> do
-                      res <- lift $ receive id n
-                      case res of
-                          Left err -> throwErrorHere . OtherError
-                                    $ receiveName <> ": request failed: " <> err
-                          Right v' -> pure $ List v'
-          (String _, v) -> throwErrorHere $ TypeError receiveName 1 TNumber v
+          (String id, v) -> do
+              index <- case fromRad v of
+                  Right Nothing -> pure Nothing
+                  Right (Just n) -> pure (Just n)
+                  Left e ->  throwReceiveError $ "failed to parse second argument: " <> e
+              res <- lift $ receive id index
+              case res of
+                  Left err -> throwReceiveError $ "request failed: " <> err
+                  Right (newIndex, values) -> pure $ Vec $ fromList [toRad newIndex, Vec $ fromList values]
           (v, _)        -> throwErrorHere $ TypeError receiveName 0 TString v
       )
+
+    throwReceiveError :: Text -> Lang m a
+    throwReceiveError msg = throwErrorHere $ OtherError $ receiveName <> ": " <> msg

--- a/test/server.rad
+++ b/test/server.rad
@@ -1,0 +1,74 @@
+#!/usr/bin/env radicle
+;;
+;; Test correctness of the storage interface provided by the server.
+;;
+;; This script tests that the HTTP server implements the storage protocol with
+;; `send!` and `receive!` properly.
+;;
+;; The script accepts the hostname of the server as an optional argument. The
+;; hostname defaults to `localhost`. We always use port 8000.
+;;
+
+
+(load! "rad/prelude.rad")
+
+(import prelude/patterns '[/cons] :unqualified)
+(import prelude/test '[assert-equal] :unqualified)
+
+(def host
+  (match (get-args!)
+    (/cons 'h _) h
+    /nil         "localhost"
+  ))
+
+(def create-machine
+  (fn []
+    (string-append "http://" host ":8000/chains/" (uuid!))
+  ))
+
+(def exprs-1 [ :e1 :e2 ])
+(def exprs-2 [ :f1 :f2 :f3 ])
+
+(def test/receive-all
+  "Passing `:nothing` to `receive!` returns all expressions"
+  (fn []
+    (def machine-id (create-machine))
+    (send! machine-id exprs-1)
+    (send! machine-id exprs-2)
+    (def all-exprs (<> exprs-1 exprs-2))
+    (match (receive! machine-id :nothing)
+      [_ 'received-exprs] (assert-equal received-exprs all-exprs))
+  ))
+
+(def test/receive-last-index
+  (fn []
+    "Passing the last index from `send!` to `receive!` returns no expressions"
+    (def machine-id (create-machine))
+    (def index (send! machine-id exprs-1))
+    (match (receive! machine-id [:just index])
+      [_ 'received-exprs] (assert-equal received-exprs []))
+  ))
+
+(def test/receive-with-index
+  (fn []
+    "Passing an index from `send!` to `receive!` returns no expressions"
+    (def machine-id (create-machine))
+    (def index (send! machine-id exprs-1))
+    (send! machine-id exprs-2)
+    (match (receive! machine-id [:just index])
+      [_ 'received-exprs] (assert-equal received-exprs exprs-2))
+  ))
+
+(def test/receive-returns-sent-index
+  "`receive!` returns the last sent index"
+  (fn []
+    (def machine-id (create-machine))
+    (def index-send (send! machine-id exprs-1))
+    (match (receive! machine-id :nothing)
+      ['index-receive _] (assert-equal index-receive index-send))
+  ))
+
+(test/receive-all)
+(test/receive-last-index)
+(test/receive-with-index)
+(test/receive-returns-sent-index)


### PR DESCRIPTION
As a step towards RFC-0001 we implement a couple of changes. Updates to both the interpreter and the server are backwards incompatible.

* `StorageBackend` is now polymorphic in the entry index and uses the `ToRad` and `FromRad` instances.
* `storageSend` now returns the index of the submitted expression. This also requires an update of `insertExprs` in the server code.
* The index parameter to `storageReceive` is now optional.
* `storageReceive` returns an index for the last entry.
* Change the semantics of `storageReceive` so that we don’t include the item at the given index.
* Update `prelude/chain` to accommodate the interface changes.
* Add `test/server.rad` script that tests the interface against the HTTP
  server.