### PR TITLE
Use a custom stack snapshot and improve CI cache

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
-timeout: 1800s # Cache misses are slow to rebuild
+timeout: 3600s # Cache misses are slow to rebuild
 steps:
   - id: "Load cache"
     name: gcr.io/cloud-builders/gsutil
@@ -23,7 +23,7 @@ steps:
       stack config set system-ghc --global true
       stack config set install-ghc --global false
 
-      stack install stylish-haskell hlint weeder
+      stack build stylish-haskell hlint weeder
 
   - id: "Format"
     name: 'haskell:8.4.3'
@@ -150,6 +150,8 @@ steps:
     waitFor:
     - "Build & Test"
     name: gcr.io/cloud-builders/gsutil
+    env:
+    - BRANCH_NAME=$BRANCH_NAME
     entrypoint: 'bash'
     args:
     - '-c'

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -2,30 +2,40 @@
 
 set -euo pipefail
 
+dependency_hash=$( (cat package.yaml; cat snapshot.yaml) | sha256sum | cut -d ' ' -f 1)
+
+remote="gs://radicle-build-cache/v2"
+
+local_cache_archive="stack-root.tar.gz"
+remote_cache_master="$remote/stack-root-master.tar.gz"
+remote_cache_hashed="$remote/stack-root-${dependency_hash}.tar.gz"
+
 function load-cache() {
-  bucket="gs://radicle-build-cache"
-  key="stack-work-$(cat stack.yaml | sha256sum | cut -d ' ' -f 1)".tar.gz
-  gsutil -m cp -r "$bucket/v1/*" "$bucket/$key" . || true
-  for f in stack.tar.gz $key; do
-    if [[ -e $f ]]; then
-      tar xzf $f
-    fi
-  done
+  if gsutil ls "$remote_cache_hashed"; then
+    gsutil -m cp "$remote_cache_hashed" "$local_cache_archive"
+    tar xzf "$local_cache_archive"
+  elif gsutil ls "$remote_cache_master"; then
+    gsutil -m cp "$remote_cache_master" "$local_cache_archive"
+    tar xzf "$local_cache_archive"
+  fi
+}
+
+function build-cache() {
+  if [ ! -f "$local_cache_archive" ]; then
+    # This file is not needed and unecessarily large
+    rm -rf .stack/indices/Hackage/00-index.tar*
+
+    tar czf $local_cache_archive .stack
+  fi
 }
 
 function save-cache() {
-  bucket="gs://radicle-build-cache"
-  key="stack-work-$(cat stack.yaml | sha256sum | cut -d ' ' -f 1)".tar.gz
-  if ! gsutil ls "$bucket/$key"; then
-    tar czf $key .stack-work
-    gsutil -m cp $key "$bucket/$key" || true
+  if ! gsutil ls "$remote_cache_hashed"; then
+    build-cache
+    gsutil -m cp $local_cache_archive "$remote_cache_hashed" || true
   fi
 
-  rm -rf .stack/indices/Hackage/00-index.tar*
-  tar czf stack.tar.gz .stack
-
-  if ! sha256sum --check stack.tar.gz.sha256; then
-    sha256sum stack.tar.gz >stack.tar.gz.sha256
-    gsutil -m cp stack.tar.gz* "$bucket/v1/" || true
+  if [ "$BRANCH_NAME" = "master" ]; then
+    gsutil -m cp "$remote_cache_hashed" "$remote_cache_master" || true
   fi
 }

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -1,0 +1,14 @@
+# Custom snapshot based on stackage LTS with additional dependencies required
+# by radicle.
+#
+# Add entries to `packages` instead of `extra-deps` in `stack.yaml`
+#
+# See https://docs.haskellstack.org/en/stable/custom_snapshot/
+#
+name: radicle-deps-12.9
+resolver: lts-12.9
+
+packages:
+- acid-state-0.14.3
+- cborg-0.2.0.0
+- serialise-0.2.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-12.9
+resolver: snapshot.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -37,12 +37,9 @@ resolver: lts-12.9
 # will not be run. This is useful for tweaking upstream packages.
 packages:
 - .
-# Dependency packages to be pulled from upstream that are not in the resolver
-# (e.g., acme-missiles-0.3)
-extra-deps:
-- serialise-0.2.0.0
-- cborg-0.2.0.0
-- acid-state-0.14.3
+
+# Add extra deps as `packages` to `snapshot.yaml`.
+# extra-deps:
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
We now use a custom stack snapshot instead of specifying `extra-deps` in `stack.yaml` and tweak the CI caching scripts.

Before the CI build caching suffered from a couple of problems:

* A cache for `STACK_ROOT` would always be uploaded after the build. (I don’t know why.)
* We cached the build artifacts in `.stack-work` keyed by the has of `stack.yaml`. This resulted in many builds sharing building artifacts which could potentially result in bugs.

With this commit we stop caching build artifacts and improve the caching strategy for `STACK_ROOT`.

By using a snapshot the artifacts for the extra packages (e.g. `cbor`) are build in `STACK_ROOT` and cached. (Including the extra packages in the cache was the initial reason for caching `.stack-work`)

The main cache ID for `STACK_ROOT` is determined by the hash of `snapshot.yaml` and `package.yaml`. (Ideally the cache ID should be the hash of the output of `stack ls dependencies`, but this requires some further modifications.)

In addition we have a `STACK_ROOT` cache for the master branch. This cache is always uploaded for a master build. If a cache with a specific hash does not exist we load the master cache.