### PR TITLE
Modified at has to be set on import

### DIFF
--- a/rad/monadic/issues.rad
+++ b/rad/monadic/issues.rad
@@ -136,7 +136,7 @@
     (def issues (read-file-value! "githubissues.rad"))
     (def imported
       (map
-       (fn [i] (note-imported (note-comments i)))
+       (fn [i] (insert :modified-at (lookup :created-at i) (note-imported (note-comments i))))
        issues))
     (map (fn [i] (create-issue! chain i)) imported)))
 


### PR DESCRIPTION
This is a quick fix. GithubIssues code currently does not include
the modified-at timestamp. Also when creating issues on the chain
the validator checks for modified at and created at to be equal.