### PR TITLE
Rename 'Storage' to 'MachineBackend'

### DIFF
--- a/exe/RadicleExe.hs
+++ b/exe/RadicleExe.hs
@@ -9,7 +9,7 @@ import           System.Directory (doesFileExist)
 
 import           Radicle
 import           Radicle.Internal.Effects (exitCode)
-import           Radicle.Internal.HttpStorage
+import           Radicle.Internal.MachineBackend.EvalServer
 import           Radicle.Internal.Pretty (putPrettyAnsi)
 
 main :: IO ()
@@ -88,5 +88,5 @@ opts = Opts
 
 createBindings :: (MonadIO m, ReplM m) => [Text] -> IO (Bindings (PrimFns m))
 createBindings scriptArgs' = do
-    storage <- createHttpStoragePrimFns
-    pure $ addPrimFns (replPrimFns scriptArgs' <> storage) pureEnv
+    machineBackendPrimFns <- createEvalServerBackendPrimFns
+    pure $ addPrimFns (replPrimFns scriptArgs' <> machineBackendPrimFns) pureEnv

--- a/exe/Server.hs
+++ b/exe/Server.hs
@@ -48,7 +48,7 @@ import           Servant
                  )
 
 import           Radicle
-import           Radicle.Internal.HttpStorage
+import           Radicle.Internal.MachineBackend.EvalServer
 import           Server.DB
 
 -- * Types

--- a/test/spec/Radicle/Internal/TestCapabilities.hs
+++ b/test/spec/Radicle/Internal/TestCapabilities.hs
@@ -26,7 +26,7 @@ import qualified System.FilePath.Find as FP
 import           Radicle
 import           Radicle.Internal.Crypto
 import           Radicle.Internal.Effects.Capabilities
-import           Radicle.Internal.Storage
+import           Radicle.Internal.MachineBackend.Interface
 import qualified Radicle.Internal.UUID as UUID
 
 
@@ -116,14 +116,14 @@ sourceFiles = do
 
 -- | Bindings with REPL and client stuff mocked.
 testBindings :: Bindings (PrimFns (StateT WorldState IO))
-testBindings = addPrimFns storagePrimFns (replBindings [])
+testBindings = addPrimFns memoryMachineBackendPrimFns (replBindings [])
 
 -- | Provides @send!@ and @receive!@ functions that store chains in a
 -- 'Map' in the 'WorldState'.
-storagePrimFns :: PrimFns (StateT WorldState IO)
-storagePrimFns =
-    buildStoragePrimFns StorageBackend
-        { storageSend =
+memoryMachineBackendPrimFns :: PrimFns (StateT WorldState IO)
+memoryMachineBackendPrimFns =
+    buildMachineBackendPrimFns MachineBackend
+        { machineUpdate =
             ( "send!"
             , "Mocked version of `send!` that stores sent values in a map with chains as keys."
             , \id values -> do
@@ -134,7 +134,7 @@ storagePrimFns =
                    s { worldStateRemoteChains = Map.insert id newExprs $ worldStateRemoteChains s }
                 pure $ Right $ Seq.length newExprs
             )
-        , storageReceive =
+        , machineGetLog =
             ( "receive!"
             , "Mocked version of `receive!` that retrieves values from a map with chains as keys."
             , \id maybeIndex -> do


### PR DESCRIPTION
As part of RFC 0001 we rename a couple of things in the storage interface. No changes to the logic.