### PR TITLE
Correctly order results when loading initial state

### DIFF
--- a/exe/Server.hs
+++ b/exe/Server.hs
@@ -113,7 +113,9 @@ loadState conn = do
         let go acc x = eval x >>= \v -> pure (acc Seq.|> (x, v))
         let st = runIdentity $ runLang pureEnv $ foldM go mempty vals
         case st of
-            (Left err, _) -> panic $ show err
+            (Left err, _) -> do
+                logInfo "Failed to load machine" [("machine", name)]
+                panic $ show err
             (Right pairs, st') -> do
                 let c = Chain { chainName = name
                               , chainState = st'


### PR DESCRIPTION
Smaller fix for problem addressed in #350

This fix an issue where the server failed to load the machines from the database. The underlying problem was that rows from the DB where not correctly grouped by chain name. The `groupBy` function only groups *adjacent* items in a list.