### PR TITLE
Reverse order issues are listed

### DIFF
--- a/bin/rad-issues
+++ b/bin/rad-issues
@@ -133,7 +133,7 @@
            (match last-seen
              (/just 't) (recent-activity chain-ref t)
              _          (map (fn [i] {:issue i})
-                             (values (list-issues chain-ref))))))
+                             (reverse (values (list-issues chain-ref)))))))
 
     (if (empty-seq? items)
       (put-str! "No recent items!")


### PR DESCRIPTION
Now we show the most recently added issues at the bottom of the list, hiding older issues “behind the fold”.