### PR TITLE
Only install chain macro in REPL

### DIFF
--- a/rad/prelude.rad
+++ b/rad/prelude.rad
@@ -33,15 +33,3 @@
 (import prelude/validation :as 'validator)
 (import prelude/util :unqualified)
 (import prelude/chain :as 'chain)
-(import prelude/chain '[eval] :unqualified)
-
-(def _initial-prompt-text
-  "Text used for greeting in the repl."
-  "Welcome to radicle. Type (help) for help.")
-
-(def help
-  "Default help text."
-  (fn []
-    "radicle is a LISP-like language intended for programming chains, and interacting with those chains.
-
-    Type (doc '<name>) for further documentation of <name>."))

--- a/rad/repl.rad
+++ b/rad/repl.rad
@@ -1,6 +1,12 @@
 (load! "rad/prelude.rad")
+(import prelude/chain '[eval] :unqualified)
 
-;; The Repl
+(def help
+  "Default help text."
+  (fn []
+    "radicle is a LISP-like language intended for programming chains, and interacting with those chains.
+
+    Type (doc '<name>) for further documentation of <name>."))
 
 (def read-line-or-exit! (fn []
   (def line (get-line!))


### PR DESCRIPTION
We only install the `:enter-remote-chain` macro in the REPL, not in the prelude. Should give us some performance improvements.