### PR TITLE
Use machine backend type to make primfn names

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -1092,6 +1092,22 @@ Send the pure prelude to a chain.
 
 Send code from a file to a remote chain.
 
+``(send! machine-id inputs)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Update a machine with the vector of ``inputs`` to evaluate. Returns an
+index that identifies that last input. This index can be passed to
+``receive!``
+
+``(receive! machine-id index)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Get inputs from a machine. Returns a ``[index inputs]`` pair where
+``inputs`` is a vector of expressions and ``index`` is the index of the
+last input in ``inputs``. The ``index`` argument is either ``:nothing``
+in which case all inputs are fetched or ``[:just i]`` in which case all
+inputs following after the index ``i`` are fetched.
+
 ``prelude/state-machine``
 -------------------------
 

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -786,11 +786,6 @@ Read a single radicle value from a file.
 
 Read many radicle values from a file.
 
-``(send-code! chain-id filename)``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Send code from a file to a remote chain.
-
 ``(shell-with-stdout! command to-write)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1091,6 +1086,11 @@ while also calling the callback on the result.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Send the pure prelude to a chain.
+
+``(send-code! chain-id filename)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Send code from a file to a remote chain.
 
 ``prelude/state-machine``
 -------------------------

--- a/rad/examples/counter.rad
+++ b/rad/examples/counter.rad
@@ -31,7 +31,7 @@
 (def counter/init-chain!
   "Send the counter application prelude to a chain."
   (fn [chain-id]
-    (send! chain-id counter/prelude)
+    (chain/send! chain-id counter/prelude)
     :done
 ))
 
@@ -41,7 +41,7 @@
     (def chain (chain/load-chain! chain-id))
     (def expr '(increment))
     (def result (lookup :result (chain/eval-in-chain expr chain)))
-    (send! chain-id [expr])
+    (chain/send! chain-id [expr])
     result
 ))
 

--- a/rad/monadic/issues.rad
+++ b/rad/monadic/issues.rad
@@ -58,8 +58,9 @@
 (def send-signed-command!
   "Send a command signed by the keys in `my-keys.rad`."
   (fn [chain cmd payload]
-    (send! (lookup :url (read-ref chain))
-           [(list cmd (sign-entity! payload))])))
+    (chain/send!
+      (lookup :url (read-ref chain))
+      [(list cmd (sign-entity! payload))])))
 
 (def create-issue!
   "Create a new remote issue with the keys in `my-keys.rad`."

--- a/rad/monadic/issues.rad
+++ b/rad/monadic/issues.rad
@@ -7,6 +7,7 @@
 (load! "rad/prelude.rad")
 
 (import prelude/lens :unqualified)
+(import prelude/chain '[send-code! ]:unqualified)
 
 (def radicle-issues-chain-id
   "The name of this chain."

--- a/rad/monadic/names.rad
+++ b/rad/monadic/names.rad
@@ -20,7 +20,7 @@
 
 (def add-name!
   (fn [name-chain-url name key]
-    (send!
+    (chain/send!
        name-chain-url
        [(list 'add-name name key)])))
 

--- a/rad/monadic/names.rad
+++ b/rad/monadic/names.rad
@@ -3,7 +3,7 @@
 (def create-name-chain!
   (fn [url]
     (chain/send-prelude! url)
-    (send-code! url "rad/monadic/names-remote.rad")))
+    (chain/send-code! url "rad/monadic/names-remote.rad")))
 
 (def lookup-key
   (fn [chain-ref key]

--- a/rad/prelude/chain.rad
+++ b/rad/prelude/chain.rad
@@ -1,6 +1,8 @@
 {:module 'prelude/chain
  :doc "Functions for simulating remote chains."
- :exports '[new-chain load-chain! eval-in-chain update-chain-ref! eval updatable-eval update-chain! eval-fn-app send-prelude!]}
+ :exports '[new-chain load-chain! eval-in-chain update-chain-ref! eval
+            updatable-eval update-chain! eval-fn-app send-prelude!
+            send-code!]}
 
 (import prelude/io '[read-file-values!] :as 'io)
 (import prelude/ref '[modify-ref] :unqualified)
@@ -215,3 +217,8 @@
   "Send the pure prelude to a chain."
   (fn [chain-id]
     (send! chain-id pure-prelude-code)))
+
+(def send-code!
+  "Send code from a file to a remote chain."
+  (fn [chain-id filename]
+    (send! chain-id (io/read-file-values! filename))))

--- a/rad/prelude/chain.rad
+++ b/rad/prelude/chain.rad
@@ -2,7 +2,7 @@
  :doc "Functions for simulating remote chains."
  :exports '[new-chain load-chain! eval-in-chain update-chain-ref! eval
             updatable-eval update-chain! eval-fn-app send-prelude!
-            send-code!]}
+            send-code! send! receive!]}
 
 (import prelude/io '[read-file-values!] :as 'io)
 (import prelude/ref '[modify-ref] :unqualified)
@@ -15,6 +15,22 @@
 ;;   - A known starting state (i.e. environment, and the assumption that `eval
 ;;     == base-eval')
 ;;   - A sequence of inputs.
+
+(def send!
+  "Update a machine with the vector of `inputs` to evaluate. Returns an
+  index that identifies that last input. This index can be passed to
+  `receive!`"
+  (fn [machine-id inputs]
+    (machine/eval-server/update! machine-id inputs)))
+
+(def receive!
+  "Get inputs from a machine. Returns a `[index inputs]` pair where
+  `inputs` is a vector of expressions and `index` is the index of the
+  last input in `inputs`. The `index` argument is either `:nothing` in
+  which case all inputs are fetched or `[:just i]` in which case all
+  inputs following after the index `i` are fetched."
+  (fn [machine-id index]
+    (machine/eval-server/get-log! machine-id index)))
 
 (def @var
   "A lens for variables in states of chains."

--- a/rad/prelude/io.rad
+++ b/rad/prelude/io.rad
@@ -1,6 +1,6 @@
 {:module 'prelude/io
  :doc "Some basic I/O functions."
- :exports '[print! shell! process! read-line! read-file-value! read-file-values! send-code!
+ :exports '[print! shell! process! read-line! read-file-value! read-file-values!
             shell-with-stdout! shell-no-stdin! process-with-stdout! write-file!
             init-file-dict! read-file-key! write-file-key! ls! modify-file!
            ]}
@@ -21,11 +21,6 @@
   "Read many radicle values from a file."
   (fn [file]
     (read-many-annotated file (read-file! file))))
-
-(def send-code!
-  "Send code from a file to a remote chain."
-  (fn [chain-id filename]
-    (send! chain-id (read-file-values! filename))))
 
 (def print!
   "Print a value to the console or stdout."

--- a/test/server.rad
+++ b/test/server.rad
@@ -3,7 +3,7 @@
 ;; Test correctness of the storage interface provided by the server.
 ;;
 ;; This script tests that the HTTP server implements the storage protocol with
-;; `send!` and `receive!` properly.
+;; `machine/eval-server/update!` and `machine/eval-server/get-log!` properly.
 ;;
 ;; The script accepts the hostname of the server as an optional argument. The
 ;; hostname defaults to `localhost`. We always use port 8000.
@@ -30,41 +30,41 @@
 (def exprs-2 [ :f1 :f2 :f3 ])
 
 (def test/receive-all
-  "Passing `:nothing` to `receive!` returns all expressions"
+  "Passing `:nothing` to `machine/eval-server/get-log!` returns all expressions"
   (fn []
     (def machine-id (create-machine))
-    (send! machine-id exprs-1)
-    (send! machine-id exprs-2)
+    (machine/eval-server/update! machine-id exprs-1)
+    (machine/eval-server/update! machine-id exprs-2)
     (def all-exprs (<> exprs-1 exprs-2))
-    (match (receive! machine-id :nothing)
+    (match (machine/eval-server/get-log! machine-id :nothing)
       [_ 'received-exprs] (assert-equal received-exprs all-exprs))
   ))
 
 (def test/receive-last-index
   (fn []
-    "Passing the last index from `send!` to `receive!` returns no expressions"
+    "Passing the last index from `machine/eval-server/update!` to `machine/eval-server/get-log!` returns no expressions"
     (def machine-id (create-machine))
-    (def index (send! machine-id exprs-1))
-    (match (receive! machine-id [:just index])
+    (def index (machine/eval-server/update! machine-id exprs-1))
+    (match (machine/eval-server/get-log! machine-id [:just index])
       [_ 'received-exprs] (assert-equal received-exprs []))
   ))
 
 (def test/receive-with-index
   (fn []
-    "Passing an index from `send!` to `receive!` returns no expressions"
+    "Passing an index from `machine/eval-server/update!` to `machine/eval-server/get-log!` returns no expressions"
     (def machine-id (create-machine))
-    (def index (send! machine-id exprs-1))
-    (send! machine-id exprs-2)
-    (match (receive! machine-id [:just index])
+    (def index (machine/eval-server/update! machine-id exprs-1))
+    (machine/eval-server/update! machine-id exprs-2)
+    (match (machine/eval-server/get-log! machine-id [:just index])
       [_ 'received-exprs] (assert-equal received-exprs exprs-2))
   ))
 
 (def test/receive-returns-sent-index
-  "`receive!` returns the last sent index"
+  "`machine/eval-server/get-log!` returns the last sent index"
   (fn []
     (def machine-id (create-machine))
-    (def index-send (send! machine-id exprs-1))
-    (match (receive! machine-id :nothing)
+    (def index-send (machine/eval-server/update! machine-id exprs-1))
+    (match (machine/eval-server/get-log! machine-id :nothing)
       ['index-receive _] (assert-equal index-receive index-send))
   ))
 


### PR DESCRIPTION
Review commit by commit

**Move `send-code!` to chain module**

We move the `send-code!` function from the `io` module to the `chain`
module.

**Use machine backend type to make primfn names**

We rename the primitive functions provided by the `eval-server` machine
backend to `machine/eval-server/update!` `machine/eval-server/get-log!`.

This allows us to restructure the Machine Backend interface. We omit the
primitive function name and the documentation for the generated primitives.
They all implement the machine backend interface so the documentation is
the same.

To change as little code as possible we define the old `send!` and
`receive!` names in the `prelude/chain` module. These will be extended when
the IPFS backend is implemented.