### PR TITLE
Fzf preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,10 @@ You can run tests with `stack test`.
 The documentation is build with `make -C docs html`. Reference documentation for
 Radicle code must be regenerated with `stack run radicle-doc-ref` and checked
 into version control.
+
+## Issues
+
+We are currently using `radicle` itself to manage issues, and have therefore
+disabled issues on Github. You can create and see issues with the
+`bin/rad-issues` script. You can also reach us on the `radicle` IRC channel on
+`#freenode`.

--- a/bin/rad-issues
+++ b/bin/rad-issues
@@ -140,7 +140,7 @@
       (put-str! "No recent items!")
       (match (fzf-select-with-preview!
                (map first items)
-               (fn [s] (show (lookup s items-dict))))
+               (fn [s] (pretty-issue (add-username-issue (lookup :issue (lookup s items-dict))))))
              (/just 's)
              (do (def selected (lookup s items-dict))
                  (def issue-number (match selected {:issue {:number 'n}} n))

--- a/bin/rad-issues
+++ b/bin/rad-issues
@@ -135,11 +135,14 @@
              _          (map (fn [i] {:issue i})
                              (reverse (values (list-issues chain-ref)))))))
 
+    (def items-dict (dict-from-seq items))
     (if (empty-seq? items)
       (put-str! "No recent items!")
-      (match (fzf-select! (map first items))
+      (match (fzf-select-with-preview!
+               (map first items)
+               (fn [s] (show (lookup s items-dict))))
              (/just 's)
-             (do (def selected (lookup s (dict-from-seq items)))
+             (do (def selected (lookup s items-dict))
                  (def issue-number (match selected {:issue {:number 'n}} n))
                  (def pretty-item
                    (add-comment-md

--- a/rad/prelude/io-utils.rad
+++ b/rad/prelude/io-utils.rad
@@ -20,19 +20,13 @@
   "Like `fzf-select!`, but includes a preview defined by `prev-fn`."
   (fn [xs prev-fn]
     (def temp-file (first (process-with-stdout! "mktemp" [] "")))
-    (def escape-str
-      (fn [s] (string-replace "\t" "\\t" (string-replace "\n" "\\n" s))))
-    (def unescape-str
-      (fn [s] (string-replace "\\t" "\t" (string-replace "\\n" "\n" s))))
+    (def d (dict-from-seq (map (fn [x] [x (prev-fn x)]) xs)))
     (def contents
-      (unlines
-        (map
-          (fn [x] (string-append (escape-str x) "\t" (escape-str (prev-fn x))))
-          xs)))
+      (string-append
+        "(def the-dict " (show d) ")"
+        "(put-str! (lookup (first (get-args!)) the-dict))"))
     (write-file! temp-file contents)
-    (def preview ["--preview" (string-append "awk -F'\t' '$1 == \"{}\" { print $2 }' " temp-file)])
-    (def preview ["--preview" "echo {}"])
-    (print! preview)
+    (def preview ["--preview" (string-append "radicle " temp-file " {}")])
     (def result (process-with-stdout! "fzf" preview (unlines xs)))
     (match result
            [] :nothing

--- a/rad/prelude/io-utils.rad
+++ b/rad/prelude/io-utils.rad
@@ -16,6 +16,28 @@
            [] :nothing
            ['x] [:just (string-replace "\n" "" x)])))
 
+(def fzf-select-with-preview!
+  "Like `fzf-select!`, but includes a preview defined by `prev-fn`."
+  (fn [xs prev-fn]
+    (def temp-file (first (process-with-stdout! "mktemp" [] "")))
+    (def escape-str
+      (fn [s] (string-replace "\t" "\\t" (string-replace "\n" "\\n" s))))
+    (def unescape-str
+      (fn [s] (string-replace "\\t" "\t" (string-replace "\\n" "\n" s))))
+    (def contents
+      (unlines
+        (map
+          (fn [x] (string-append (escape-str x) "\t" (escape-str (prev-fn x))))
+          xs)))
+    (write-file! temp-file contents)
+    (def preview ["--preview" (string-append "awk -F'\t' '$1 == \"{}\" { print $2 }' " temp-file)])
+    (def preview ["--preview" "echo {}"])
+    (print! preview)
+    (def result (process-with-stdout! "fzf" preview (unlines xs)))
+    (match result
+           [] :nothing
+           ['x] [:just (string-replace "\n" "" x)])))
+
 (def edit-in-editor!
   "Open `$EDITOR` on a file prepopulated with `orig`. Returns the contents of the edited file when the editor exits."
   (fn [orig]


### PR DESCRIPTION
Adds the function `fzf-select-with-preview!`, which allows keys to be previewed in a way defined by a preview function.

Uses that to give previews to issues:

![preview](https://i.imgur.com/4jzDWDX.png)

Navigating issues with `fzf` remains quite responsive (at least when `radicle` is compiled with optimizations).