### PR TITLE
Benchmarking

### DIFF
--- a/exe/Benchmarks.hs
+++ b/exe/Benchmarks.hs
@@ -1,37 +1,33 @@
 module Benchmarks (main) where
 
-import Protolude
+import           Protolude
 
-import Criterion.Main
+import           Criterion.Main
 
-import Radicle
+import           Radicle
 
-steps :: [Text] -> IO Value
-steps is = snd <$> foldlM step (pureEnv, Number 0) is
+steps :: [Text] -> Value
+steps is = runIdentity $ snd <$> foldlM step (pureEnv, Number 0) is
   where
     step (s,_) t = do
       (res_, s') <- interpretWithState "[bench]" t s
       case res_ of
-        Left e -> panic (show e)
+        Left e  -> panic (show e)
         Right v -> pure (s', v)
 
-counter :: Int -> IO Value
-counter i = steps $
+counter :: Int -> Rational
+counter i = unwrap $ steps $
   [ "(def i (ref 0))"
   , "(def add (fn [x] (write-ref i (+ (read-ref i) x))))"
   , "(def eval (fn [expr state] (base-eval (list 'add expr) state)))" ]
   ++ (show <$> take i (cycle [1..20::Int]))
+  where
+    unwrap (Number r) = r
+    unwrap _          = panic "expecting a number result!"
 
--- Our benchmark harness.
 main :: IO ()
-main = do
-  v <- counter 100
-  print v
-  defaultMain [
-    bgroup "counter" [ bench "10"  $ whnf counter 10
-                   , bench "50"  $ whnf counter 50
-                   , bench "1000"  $ whnf counter 1000
+main = defaultMain [
+  bgroup "counter" [ bench "1000"  $ whnf counter 1000
                    , bench "10000" $ whnf counter 10000
-                   , bench "100000" $ whnf counter 100000
                    ]
     ]

--- a/exe/Benchmarks.hs
+++ b/exe/Benchmarks.hs
@@ -1,0 +1,37 @@
+module Benchmarks (main) where
+
+import Protolude
+
+import Criterion.Main
+
+import Radicle
+
+steps :: [Text] -> IO Value
+steps is = snd <$> foldlM step (pureEnv, Number 0) is
+  where
+    step (s,_) t = do
+      (res_, s') <- interpretWithState "[bench]" t s
+      case res_ of
+        Left e -> panic (show e)
+        Right v -> pure (s', v)
+
+counter :: Int -> IO Value
+counter i = steps $
+  [ "(def i (ref 0))"
+  , "(def add (fn [x] (write-ref i (+ (read-ref i) x))))"
+  , "(def eval (fn [expr state] (base-eval (list 'add expr) state)))" ]
+  ++ (show <$> take i (cycle [1..20::Int]))
+
+-- Our benchmark harness.
+main :: IO ()
+main = do
+  v <- counter 100
+  print v
+  defaultMain [
+    bgroup "counter" [ bench "10"  $ whnf counter 10
+                   , bench "50"  $ whnf counter 50
+                   , bench "1000"  $ whnf counter 1000
+                   , bench "10000" $ whnf counter 10000
+                   , bench "100000" $ whnf counter 100000
+                   ]
+    ]

--- a/package.yaml
+++ b/package.yaml
@@ -191,7 +191,7 @@ executables:
     - optparse-applicative
     ghc-options: -main-is GithubIssues
 
-  benchmark:
+  radicle-benchmark:
     main: Benchmarks.hs
     source-dirs: exe/
     other-modules: []

--- a/package.yaml
+++ b/package.yaml
@@ -191,6 +191,18 @@ executables:
     - optparse-applicative
     ghc-options: -main-is GithubIssues
 
+  benchmark:
+    main: Benchmarks.hs
+    source-dirs: exe/
+    other-modules: []
+    when:
+      - condition: impl(ghcjs)
+        buildable: false
+    dependencies:
+    - radicle
+    - criterion
+    ghc-options: -main-is Benchmarks
+
 default-extensions:
 - AutoDeriveTypeable
 - ConstraintKinds


### PR DESCRIPTION
Simple benchmarking of a machine with an eval redefinition.

```
benchmarking counter/1000
time                 216.8 ms   (192.3 ms .. 264.0 ms)
                     0.977 R²   (0.928 R² .. 1.000 R²)
mean                 204.4 ms   (194.0 ms .. 220.0 ms)
std dev              16.38 ms   (11.21 ms .. 20.94 ms)
variance introduced by outliers: 16% (moderately inflated)

benchmarking counter/10000
time                 1.978 s    (1.830 s .. 2.104 s)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 1.979 s    (1.966 s .. 2.001 s)
std dev              22.05 ms   (619.8 μs .. 26.82 ms)
variance introduced by outliers: 19% (moderately inflated)
```