### PR TITLE
Always create new cache file when remote is missing

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -11,31 +11,30 @@ remote_cache_master="$remote/stack-root-master.tar.gz"
 remote_cache_hashed="$remote/stack-root-${dependency_hash}.tar.gz"
 
 function load-cache() {
-  if gsutil ls "$remote_cache_hashed"; then
+  if gsutil -q ls "$remote_cache_hashed"; then
+    echo "Using hashed stack cache"
     gsutil -m cp "$remote_cache_hashed" "$local_cache_archive"
     tar xzf "$local_cache_archive"
-  elif gsutil ls "$remote_cache_master"; then
+    rm "$local_cache_archive"
+  elif gsutil -q ls "$remote_cache_master"; then
+    echo "Using master stack cache"
     gsutil -m cp "$remote_cache_master" "$local_cache_archive"
     tar xzf "$local_cache_archive"
-  fi
-}
-
-function build-cache() {
-  if [ ! -f "$local_cache_archive" ]; then
-    # This file is not needed and unecessarily large
-    rm -rf .stack/indices/Hackage/00-index.tar*
-
-    tar czf $local_cache_archive .stack
+    rm "$local_cache_archive"
   fi
 }
 
 function save-cache() {
-  if ! gsutil ls "$remote_cache_hashed"; then
-    build-cache
+  if ! gsutil -q ls "$remote_cache_hashed"; then
+    echo "Uploading stack cache"
+    # This file is not needed and unecessarily large
+    rm -rf .stack/indices/Hackage/00-index.tar*
+    tar czf $local_cache_archive .stack
     gsutil -m cp $local_cache_archive "$remote_cache_hashed" || true
   fi
 
   if [ "$BRANCH_NAME" = "master" ]; then
+    echo "Setting master cache to current cache"
     gsutil -m cp "$remote_cache_hashed" "$remote_cache_master" || true
   fi
 }


### PR DESCRIPTION
Before, the `build-cache` function only created the tar archive if it
did not exist. Since we always retrieve an archive with that name at the
start of the build we would never rebuild the cache.