### PR TITLE
Handle recursive functions at call site

### DIFF
--- a/exe/ReferenceDoc.hs
+++ b/exe/ReferenceDoc.hs
@@ -99,13 +99,16 @@ lPanic (Right r) _ = r
 
 valueDoc :: Text -> Text -> Value -> [Block]
 valueDoc name docString value = case value of
-    Lambda args _ _ ->
-        let callExample = "(" <> T.intercalate " " (name : map fromIdent args) <> ")"
-        in [ Header 3 nullAttr [Code nullAttr (toS callExample) ] ]
-           <> parseMarkdownBlocks docString
+    Lambda args _ _ -> lambdaDoc args
+    LambdaRec _ args _ _ -> lambdaDoc args
     _ ->
         [ Header 3 nullAttr [Code nullAttr (toS name) ] ]
         <> parseMarkdownBlocks docString
+  where
+    lambdaDoc args =
+        let callExample = "(" <> T.intercalate " " (name : map fromIdent args) <> ")"
+        in [ Header 3 nullAttr [Code nullAttr (toS callExample) ] ]
+           <> parseMarkdownBlocks docString
 
 -- | Generate documentation for primitive functions defined by 'replBindings'
 docForPrimFns :: Content -> [Block]

--- a/src/Radicle/Internal/Pretty.hs
+++ b/src/Radicle/Internal/Pretty.hs
@@ -67,16 +67,18 @@ instance forall t. (Copointed t, Ann.Annotation t) => PrettyV (Ann.Annotated t V
         Dict mp -> braces . align $
             sep [ prettyV k <+> prettyV val
                 | (k, val) <- Map.toList mp ]
-        Lambda ids vals _ ->
+        Lambda ids vals _ -> prettyLambda ids vals
+        LambdaRec _ ids vals _ -> prettyLambda ids vals
+      where
+        -- We print string literals escaped just like Haskell does.
+        escapeStr = T.init . T.tail . show
+        prettyLambda ids vals =
           let args :: Ann.Annotated t ValueF = Vec $ Seq.fromList (Atom <$> ids)
           in parens $
                annotate TAtom "fn" <+>
                align (sep [ prettyV args
                           , sep $ prettyV <$> toList vals
                           ])
-      where
-        -- We print string literals escaped just like Haskell does.
-        escapeStr = T.init . T.tail . show
 
 instance Pretty Ann.SrcPos where
     pretty (Ann.SrcPos pos)        = pretty (sourcePosPretty pos)

--- a/test/spec/Radicle/Tests.hs
+++ b/test/spec/Radicle/Tests.hs
@@ -487,9 +487,18 @@ test_eval =
             (triangular 10)
             |]
         runPureCode prog @?= Right (int 55)
+    , testCase "def-rec shadows previous definition" $ do
+        let prog = [s|
+            (def decrement #f)
+            (def-rec decrement
+              (fn [n]
+                (if (eq? n 0) 0 (decrement (- n 1)))))
+            (decrement 10)
+            |]
+        runPureCode prog @?= Right (int 0)
 
     , testCase "def-rec errors when defining a non-function" $
-        failsWith "(def-rec x 42)" (OtherError "def-rec can only be used to define functions")
+        failsWith "(def-rec x 42)" (OtherError "'def-rec' can only be used to define functions")
 
     , testCase "stack traces work" $ do
         let prog = [s|


### PR DESCRIPTION
Instead of injecting the recursive reference to a function into the closure when defining the recursive function we inject it into the environment when calling the function. This should eliminate circular references from `Env`.