### PR TITLE
Revert `rad-issues` URL to use production machine host

### DIFF
--- a/bin/rad-issues
+++ b/bin/rad-issues
@@ -6,9 +6,9 @@
 
 (import prelude/validation :as 'validation)
 
-(def base-name "http://staging.machines.radicle.xyz/chains/")
+(def base-name "http://machines.radicle.xyz/chains/")
 
-(def name-base "http://staging.machines.radicle.xyz/chains/names")
+(def name-base "http://machines.radicle.xyz/chains/names")
 
 (def help
   (string-append


### PR DESCRIPTION
We are moving the host for remotely hosted machines from `staging.machines.radicle.xyz` back to `machines.radicle.xyz`.

See also https://github.com/oscoin/infrastructure/pull/14