### PR TITLE
Add docker-compose file to run all tests

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -156,7 +156,7 @@ steps:
     - |
       set -euxo pipefail
       stack exec -- radicle - <<<'(load! "rad/examples/counter.rad") (counter/run-test)'
-      IPFS_API_URL=http://ipfs-test-network:5001 stack exec -- radicle test/machine-backends.rad radicle-server
+      RAD_IPFS_API_URL=http://ipfs-test-network:5001 stack exec -- radicle test/machine-backends.rad radicle-server
 
   - id: "Save cache"
     waitFor:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -130,20 +130,18 @@ steps:
     - "-c"
     - |
       set -euxo pipefail
-      cd images/radicle-server
-      docker-compose up -d postgres
+      docker-compose -f test/docker-compose.yaml up -d postgres
       sleep 5 # Wait for the DB to be ready
-      docker-compose up -d
-      docker run \
-        --name ipfs-test-network \
-        --detach \
-        --publish 9301:5001 \
-        --network cloudbuild \
-        eu.gcr.io/opensourcecoin/ipfs-test-network
-      docker network connect cloudbuild radicle-server_radicle-server_1 --alias radicle-server
+      docker-compose -f test/docker-compose.yaml up -d
       sleep 3 # Wait for service to be booted
+
+      # Connect services to 'cloudbuild' network so they can be
+      # accessed by other steps
+      docker network connect cloudbuild test_radicle-server_1 --alias radicle-server
+      docker network connect cloudbuild test_ipfs-test-network_1 --alias ipfs-test-network
+
       # Add the empty entry to the IPFS test network. Radicle requires it
-      echo '{"radicle": true}' | docker exec -i ipfs-test-network ipfs dag put --pin
+      echo '{"radicle": true}' | docker exec -i test_ipfs-test-network_1 ipfs dag put --pin
 
   - id: "Integration tests"
     waitFor:

--- a/src/Radicle/Internal/MachineBackend/Ipfs.hs
+++ b/src/Radicle/Internal/MachineBackend/Ipfs.hs
@@ -306,7 +306,7 @@ ipfsHttpPost path payloadArgName payload = do
 
 ipfsApiUrl :: Text -> IO Text
 ipfsApiUrl path = do
-    baseUrl <- fromMaybe "http://localhost:9301" <$> lookupEnv "IPFS_API_URL"
+    baseUrl <- fromMaybe "http://localhost:9301" <$> lookupEnv "RAD_IPFS_API_URL"
     pure $ toS baseUrl <> "/api/v0/" <> path
 
 handleRequestException :: MonadThrow m => HttpException -> m a

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -1,0 +1,31 @@
+# Defines all services required for end-to-end tests
+version: '3'
+
+services:
+  postgres:
+    image: postgres:11-alpine
+    ports:
+    - "15432:5432"
+    volumes:
+      - pg-data:/var/lib/postgresql/data
+  radicle-server:
+    image: eu.gcr.io/opensourcecoin/radicle-server
+    build: ../images/radicle-server
+    depends_on:
+    - postgres
+    command:
+    - radicle-server
+    - --host=postgres
+    - --db=postgres
+    ports:
+    - "8000:8000"
+
+  ipfs-test-network:
+    image: eu.gcr.io/opensourcecoin/ipfs-test-network
+    ports:
+    - "19301:5001"
+
+
+volumes:
+  pg-data: {}
+


### PR DESCRIPTION
Add `test/docker-compose.yaml` that provides all services required to
run the machine backend tests.

Also includes a commit that adds the `RAD_` prefix to an environment
variable.