### PR TITLE
End-to-end tests for 'counter' app

### DIFF
--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -21,3 +21,10 @@
           - prettyEither
           - stackTraceLines
       # END
+  - section:
+    - name: test:e2e
+    - message:
+      - name: Redundant build-depends entry
+      - depends:
+        # Required as compiler plugin
+        - tasty-discover

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ use `images/radicle-server/docker-compose.yaml`.
 
 You can run tests with `stack test`.
 
+The end-to-end test suite is run with `stack test :e2e`. It requires you to
+start up an IPFS test network with
+
+    docker-compose -f test/docker-compose.yaml up -d ipfs-test-network
+
 The documentation is build with `make -C docs html`. Reference documentation for
 Radicle code must be regenerated with `stack run radicle-doc-ref` and checked
 into version control.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
     env: ['STACK_ROOT=/workspace/.stack']
     args: ['stack', 'exec', '--', 'hlint', '.']
 
-  - id: "Build & Test"
+  - id: "Build"
     name: 'haskell:8.6.3'
     env: ['STACK_ROOT=/workspace/.stack']
     entrypoint: bash
@@ -46,21 +46,38 @@ steps:
 
       apt-get -qq update
       apt-get -yqq install libpq-dev
-      stack build --fast --test --no-terminal --pedantic
 
-      stack exec -- radicle test/all.rad
+      stack build \
+        --no-terminal \
+        --fast \
+        --pedantic \
+        --test \
+        --no-run-tests
 
       ./images/radicle-server/ci-copy-bin.sh
 
+  - id: "Test"
+    name: 'haskell:8.6.3'
+    env: ['STACK_ROOT=/workspace/.stack']
+    entrypoint: bash
+    args:
+    - '-c'
+    - |
+      set -euxo pipefail
+
+      stack test :doctest
+      stack test :spec
+      stack exec -- radicle test/all.rad
+
   - id: "Lint (weeder)"
-    waitFor: ["Build & Test"]
+    waitFor: ["Build"]
     name: 'haskell:8.6.3'
     env: ["STACK_ROOT=/workspace/.stack"]
     args: ["stack", "exec", "--", "weeder", "--match"]
 
   - id: "Build reference document"
     waitFor:
-    - "Build & Test"
+    - "Build"
     name: 'haskell:8.6.3'
     env: ['STACK_ROOT=/workspace/.stack']
     entrypoint: bash
@@ -78,7 +95,7 @@ steps:
 
   - id: "Check tutorial"
     waitFor:
-    - "Build & Test"
+    - "Build"
     name: 'haskell:8.6.3'
     env: ['STACK_ROOT=/workspace/.stack']
     entrypoint: bash
@@ -91,7 +108,7 @@ steps:
 
   - id: "Build radicle-server image"
     waitFor:
-    - "Build & Test"
+    - "Build"
     name: 'gcr.io/cloud-builders/docker'
     entrypoint: bash
     env:
@@ -153,12 +170,13 @@ steps:
     - "-c"
     - |
       set -euxo pipefail
-      stack exec -- radicle - <<<'(load! "rad/examples/counter.rad") (counter/run-test)'
-      RAD_IPFS_API_URL=http://ipfs-test-network:5001 stack exec -- radicle test/machine-backends.rad radicle-server
+      export RAD_IPFS_API_URL=http://ipfs-test-network:5001
+      stack test :e2e
+      stack exec -- radicle test/machine-backends.rad radicle-server
 
   - id: "Save cache"
     waitFor:
-    - "Build & Test"
+    - "Build"
     name: gcr.io/cloud-builders/gsutil
     env:
     - BRANCH_NAME=$BRANCH_NAME

--- a/examples/radicle-counter
+++ b/examples/radicle-counter
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 usage() {
   cat <<USAGEDOC

--- a/package.yaml
+++ b/package.yaml
@@ -11,6 +11,7 @@ extra-source-files:
 dependencies:
 - base >=4 && <5
 - protolude
+
 ghc-options:
   - -Wall
   - -Wcompat
@@ -88,6 +89,15 @@ tests:
     - doctest
     - Glob
     - hpack
+  e2e:
+    main: Main.hs
+    source-dirs:
+    - test/e2e
+    dependencies:
+    - process
+    - tasty
+    - tasty-discover
+    - tasty-hunit
 
 executables:
   radicle:

--- a/rad/examples/counter.rad
+++ b/rad/examples/counter.rad
@@ -51,14 +51,3 @@
     (def chain (chain/load-chain! chain-id))
     (lookup :result (chain/eval-in-chain '(get-value) chain))
 ))
-
-(def counter/run-test
-  (fn []
-    (def chain-id (string-append "http://radicle-server:8000/chains/" (uuid!)))
-    (assert-equal (counter/init-chain! chain-id) :done)
-    (assert-equal (counter/get-value chain-id) 0)
-    (assert-equal (counter/increment! chain-id) 1)
-    (assert-equal (counter/increment! chain-id) 2)
-    (assert-equal (counter/get-value chain-id) 2)
-    :test-ok
-) )

--- a/test/e2e/CounterAppTest.hs
+++ b/test/e2e/CounterAppTest.hs
@@ -1,0 +1,72 @@
+-- | Test the @example/radicle-counter@ app.
+--
+-- Requires access to an IPFS daemon.
+module CounterAppTest
+    ( test_counter_app
+    ) where
+
+import           Prelude (String, unwords)
+import           Protolude
+
+import           Data.List (lookup)
+import           System.Environment
+import           System.Process
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+test_counter_app :: TestTree
+test_counter_app = testCaseSteps "counter app" $ \step -> do
+        step "Create machine"
+        machineId <- runTestCommand "rad-machines" ["create"]
+
+        step "Initialize machine"
+        let machineUrl = "ipfs://" <> machineId
+        void $ runTestCommand "examples/radicle-counter" [machineUrl, "init"]
+
+        initialValue <- runTestCommand "examples/radicle-counter" [machineUrl, "get-value"]
+        assertEqual "(get-value) on counter chain" "0" initialValue
+
+        forM_ [(1::Int)..3] $ \i -> do
+            step $ "Increment to " <> show i
+
+            valueInc <- runTestCommand "examples/radicle-counter" [machineUrl, "increment"]
+            assertEqual "(increment) on counter chain" (show i) valueInc
+
+            valueGet <- runTestCommand "examples/radicle-counter" [machineUrl, "get-value"]
+            assertEqual "(get-value) on counter chain" (show i) valueGet
+
+-- | Run a command with the given arguments and return stdout.
+--
+-- If the command exists with a non-zero exit code an exception is
+-- thrown.
+--
+-- Set the @RAD_IPFS_API_URL@ to a value that makes it work for local
+-- tests with @test/docker-compose.yaml@.
+--
+-- Any trailing newlines are stripped from the output.
+runTestCommand :: FilePath -> [String] -> IO String
+runTestCommand bin args = do
+    env <- getEnvironment
+    let procEnv = setDefault "RAD_IPFS_API_URL" "http://localhost:19301" env
+    let procSpec = (proc bin args) { env = Just procEnv }
+    (exitCode, out, err) <- readCreateProcessWithExitCode procSpec ""
+    case exitCode of
+        ExitSuccess -> pure $ trimNewline out
+        ExitFailure _ ->
+            let commandLine = bin <> " " <> unwords args
+            in assertFailure $
+                "Command failed: " <> commandLine <> "\n"
+                <> "-- stdout ---------\n"
+                <> out
+                <> "-- stderr ---------\n"
+                <> err
+                <> "-------------------\n"
+  where
+    setDefault :: Eq key => key -> value -> [(key, value)] -> [(key, value)]
+    setDefault defKey defValue items =
+        case lookup defKey items of
+            Nothing -> (defKey, defValue):items
+            Just _  -> items
+
+trimNewline :: String -> String
+trimNewline = reverse . dropWhile (=='\n') . reverse

--- a/test/e2e/Main.hs
+++ b/test/e2e/Main.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF tasty-discover #-}


### PR DESCRIPTION
We introduce end-to-end tests for the 'counter' app. The tests just call
commands and expect the IPFS daemon to be running. When the Radicle
daemon is implemented it should be easy to adapter these tests