### PR TITLE
Implement basic rad top-level command

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -203,3 +203,4 @@ language_extensions:
   - TupleSections
   - TypeFamilies
   - TypeOperators
+  - TypeApplications

--- a/exe/Rad.hs
+++ b/exe/Rad.hs
@@ -9,10 +9,11 @@ import           Protolude
 import           Data.List (isPrefixOf)
 import           Data.String (String)
 import qualified Data.Text as T
+import           Data.Version (showVersion)
 import           System.Directory
 import qualified System.Posix.Process as Posix
 
-import           Paths_radicle (getBinDir)
+import           Paths_radicle (getBinDir, version)
 
 -- | All command filenames are prefixed with this.
 radPrefix :: String
@@ -26,7 +27,7 @@ runCommand [] = do
     putStrLn @Text "Available rad commands:"
     putStr $ T.unlines $ ["   " <> T.pack c | c <- cmds]
 runCommand ("version":_) =
-    putStrLn ("rad version 1.0" :: Text)
+    putStrLn ("rad version " <> toS (showVersion version) :: Text)
 runCommand ("help":_) =
     runCommand []
 runCommand ("--help":_) =

--- a/package.yaml
+++ b/package.yaml
@@ -108,9 +108,6 @@ executables:
     - directory
     - unix
     - text
-    when:
-      - condition: impl(ghcjs)
-        buildable: false
     ghc-options: -main-is Rad -O3 -threaded
 
   radicle:

--- a/package.yaml
+++ b/package.yaml
@@ -100,6 +100,19 @@ tests:
     - tasty-hunit
 
 executables:
+  rad:
+    main: Rad.hs
+    source-dirs: exe
+    other-modules: [Paths_radicle]
+    dependencies:
+    - directory
+    - unix
+    - text
+    when:
+      - condition: impl(ghcjs)
+        buildable: false
+    ghc-options: -main-is Rad -O3 -threaded
+
   radicle:
     main: RadicleExe.hs
     source-dirs: exe


### PR DESCRIPTION
Implements a top-level entry point command, `rad`.

`rad`, `rad help`, `rad --help` and `rad -h` all just print the list of available commands.

Notes:
* I started off with optparse-applicative, but it was getting too complicated, probably in part due to my lack of knowledge of the library, so I opted for a quick and dirty approach. It'll be easy to refactor to optparse-applicative when/if we need more complex parsing.
* Presumably doesn't work on some platforms due to the use of `executeFile` (exec)
* Checks the `bin` dir for now for sub-commands, though eventually we might want to use `/usr/local/libexec`.
* ~~The `rad version` command is a placeholder, we'll have to have it pick up the actual version somehow, maybe as another changeset.~~