### PR TITLE
Save build cache even on failure

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,7 +23,30 @@ steps:
       stack config set system-ghc --global true
       stack config set install-ghc --global false
 
-      stack build stylish-haskell hlint weeder
+      stack build \
+        --no-terminal \
+        stylish-haskell hlint weeder
+
+      apt-get -qq update
+      apt-get -yqq install libpq-dev
+
+      stack build \
+        --no-terminal \
+        --dependencies-only
+
+  - id: "Save cache"
+    waitFor: ["Build deps"]
+    name: gcr.io/cloud-builders/gsutil
+    entrypoint: 'bash'
+    env:
+    - BRANCH_NAME=$BRANCH_NAME
+    args:
+    - '-c'
+    - |
+      set -euxo pipefail
+
+      source scripts/ci.sh
+      save-cache
 
   - id: "Format"
     name: 'haskell:8.6.3'
@@ -178,18 +201,3 @@ steps:
 
       stack test :e2e
       stack exec -- radicle test/machine-backends.rad radicle-server
-
-  - id: "Save cache"
-    waitFor:
-    - "Build"
-    name: gcr.io/cloud-builders/gsutil
-    env:
-    - BRANCH_NAME=$BRANCH_NAME
-    entrypoint: 'bash'
-    args:
-    - '-c'
-    - |
-      set -euxo pipefail
-
-      source scripts/ci.sh
-      save-cache

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -30,11 +30,11 @@ function save-cache() {
     # This file is not needed and unecessarily large
     rm -rf .stack/indices/Hackage/00-index.tar*
     tar czf $local_cache_archive .stack
-    gsutil -m cp $local_cache_archive "$remote_cache_hashed" || true
+    gsutil -m cp $local_cache_archive "$remote_cache_hashed"
   fi
 
   if [ "$BRANCH_NAME" = "master" ]; then
     echo "Setting master cache to current cache"
-    gsutil -m cp "$remote_cache_hashed" "$remote_cache_master" || true
+    gsutil -m cp "$remote_cache_hashed" "$remote_cache_master"
   fi
 }


### PR DESCRIPTION
We want to save the build cache for dependencies even if the project code fails to build or the tests fail. Before a test failure would prevent the build cache from being uploaded. This meant that the next build that fixed the tests would need to rebuild all the new dependencies.