### PR TITLE
Handle my-keys via key-mgmt module & add a key creation command

### DIFF
--- a/bin/rad-create-keys
+++ b/bin/rad-create-keys
@@ -1,7 +1,6 @@
 #!/usr/bin/env radicle
 
 (load! (find-module-file! "prelude.rad"))
-(load! (find-module-file! "prelude/cmd-parsing.rad"))
 
 (import prelude/key-management :as 'key-mgmt)
 

--- a/bin/rad-create-keys
+++ b/bin/rad-create-keys
@@ -5,6 +5,18 @@
 
 (import prelude/key-management :as 'key-mgmt)
 
+(def help
+  "rad-create-keys - Radicle Key Management CLI
+
+   Usage:
+        rad-create-keys [--force]
+        rad-create-keys help
+
+   Create a new key pair with `rad-create-keys`. If `--force` is appended, an
+   existing key pair file will be overwritten.
+   Per default, key pairs are stored in `$HOME/.config/radicle/my-keys.rad`
+   this can be adjusted by setting `$XDG_CONFIG_HOME`.")
+
 (def make-keys
   (fn [] (key-mgmt/create-keys!)))
 
@@ -18,4 +30,5 @@ If you are sure that you want to replace your key pair, run `rad-create-keys --f
 (def args (get-args!))
 (match args
   ["--force"] (make-keys)
-  []          (safe-make-keys))
+  []          (safe-make-keys)
+  _           (put-str! help))

--- a/bin/rad-create-keys
+++ b/bin/rad-create-keys
@@ -1,0 +1,21 @@
+#!/usr/bin/env radicle
+
+(load! (find-module-file! "prelude.rad"))
+(load! (find-module-file! "prelude/cmd-parsing.rad"))
+
+(import prelude/key-management :as 'key-mgmt)
+
+(def make-keys
+  (fn [] (key-mgmt/create-keys!)))
+
+(def safe-make-keys
+  (fn []
+    (match (key-mgmt/read-keys!)
+      :nothing  (make-keys)
+      _         (put-str! "The `my-keys.rad` file already exists.
+If you are sure that you want to replace your key pair, run `rad-create-keys --force`"))))
+
+(def args (get-args!))
+(match args
+  ["--force"] (make-keys)
+  []          (safe-make-keys))

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -1146,8 +1146,8 @@ file doesn't exist.
 
 Creates a new key pair and stores it in ``my-keys.rad``
 
-``(use-fake-keys)``
-~~~~~~~~~~~~~~~~~~~
+``(use-fake-keys!)``
+~~~~~~~~~~~~~~~~~~~~
 
 Bypass reading the keys from ``my-keys.rad``. This is intended for
 testing.

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -1127,6 +1127,28 @@ Like ``set``, but for refs.
 
 Like ``over``, but for refs.
 
+``prelude/key-management``
+--------------------------
+
+Functions for key management.
+
+``(read-keys!)``
+~~~~~~~~~~~~~~~~
+
+Reads the keys stored in ``my-keys.rad`` or returns ``:nothing`` if the
+file doesn't exist.
+
+``(create-keys!)``
+~~~~~~~~~~~~~~~~~~
+
+Creates a new key pair and stores it in ``my-keys.rad``
+
+``(use-fake-keys)``
+~~~~~~~~~~~~~~~~~~~
+
+Bypass reading the keys from ``my-keys.rad``. This is intended for
+testing.
+
 ``prelude/chain``
 -----------------
 

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -1130,7 +1130,10 @@ Like ``over``, but for refs.
 ``prelude/key-management``
 --------------------------
 
-Functions for key management.
+Providing functions for creating and reading key pairs for signing send
+commands. Per default, key pairs are stored in
+``$HOME/.config/radicle/my-keys.rad`` this can be adjusted by setting
+``$XDG_CONFIG_HOME``.
 
 ``(read-keys!)``
 ~~~~~~~~~~~~~~~~

--- a/rad/monadic/diff.rad
+++ b/rad/monadic/diff.rad
@@ -4,6 +4,7 @@
 (import prelude/chain '[send-code! ]:unqualified)
 (import prelude/time '[install-fake-clock] :unqualified)
 (import prelude/io :as 'io)
+(import prelude/key-management '[use-fake-keys] :unqualified)
 
 (def radicle-diff-chain-id
   "The name of this chain."
@@ -111,9 +112,7 @@
  [:setup
   (do (chain/install-remote-chain-fake)
       (install-fake-clock)
-      (io/install-fake-filesystem!
-        { "../my-keys.rad" (show (gen-key-pair! (default-ecc-curve)))
-        })
+      (use-fake-keys)
       (def chain-name "http://foo")
       (def chain (ref (chain/new-chain chain-name)))
       (create-diffs-chain! chain-name)

--- a/rad/monadic/diff.rad
+++ b/rad/monadic/diff.rad
@@ -4,7 +4,7 @@
 (import prelude/chain '[send-code! ]:unqualified)
 (import prelude/time '[install-fake-clock] :unqualified)
 (import prelude/io :as 'io)
-(import prelude/key-management '[use-fake-keys] :unqualified)
+(import prelude/key-management '[use-fake-keys!] :unqualified)
 
 (def radicle-diff-chain-id
   "The name of this chain."
@@ -112,7 +112,7 @@
  [:setup
   (do (chain/install-remote-chain-fake)
       (install-fake-clock)
-      (use-fake-keys)
+      (use-fake-keys!)
       (def chain-name "http://foo")
       (def chain (ref (chain/new-chain chain-name)))
       (create-diffs-chain! chain-name)

--- a/rad/monadic/issues.rad
+++ b/rad/monadic/issues.rad
@@ -11,6 +11,7 @@
 (import prelude/chain '[send-code! send-signed-command!] :unqualified)
 (import prelude/time '[install-fake-clock] :unqualified)
 (import prelude/io :as 'io)
+(import prelude/key-management '[use-fake-keys] :unqualified)
 
 (def radicle-issues-chain-id
   "The name of this chain."
@@ -174,9 +175,7 @@
  [:setup
   (do (chain/install-remote-chain-fake)
       (install-fake-clock)
-      (io/install-fake-filesystem!
-        { "../my-keys.rad" (show (gen-key-pair! (default-ecc-curve)))
-        })
+      (use-fake-keys)
       (def chain-name (string-append "http://foo"))
       (def chain (ref (chain/new-chain chain-name)))
       (create-issues-chain! chain-name)

--- a/rad/monadic/issues.rad
+++ b/rad/monadic/issues.rad
@@ -11,7 +11,7 @@
 (import prelude/chain '[send-code! send-signed-command!] :unqualified)
 (import prelude/time '[install-fake-clock] :unqualified)
 (import prelude/io :as 'io)
-(import prelude/key-management '[use-fake-keys] :unqualified)
+(import prelude/key-management '[use-fake-keys!] :unqualified)
 
 (def radicle-issues-chain-id
   "The name of this chain."
@@ -175,7 +175,7 @@
  [:setup
   (do (chain/install-remote-chain-fake)
       (install-fake-clock)
-      (use-fake-keys)
+      (use-fake-keys!)
       (def chain-name (string-append "http://foo"))
       (def chain (ref (chain/new-chain chain-name)))
       (create-issues-chain! chain-name)

--- a/rad/monadic/project.rad
+++ b/rad/monadic/project.rad
@@ -4,6 +4,7 @@
 (import prelude/chain '[send-code! send-signed-command! make-chain-ref!] :unqualified)
 (import prelude/time '[install-fake-clock] :unqualified)
 (import prelude/io :as 'io)
+(import prelude/key-management '[use-fake-keys!] :unqualified)
 
 (def get-project-url!
   (fn []
@@ -72,9 +73,7 @@
  [:setup
   (do (chain/install-remote-chain-fake)
       (install-fake-clock)
-      (io/install-fake-filesystem!
-        { "../my-keys.rad" (show (gen-key-pair! (default-ecc-curve)))
-        })
+      (use-fake-keys!)
       (def chain-name "http://bar")
       (def chain (ref (chain/new-chain chain-name)))
       (create-project! chain-name { :name "test" :description "test project"})

--- a/rad/prelude.rad
+++ b/rad/prelude.rad
@@ -14,6 +14,7 @@
 (file-module! "prelude/set.rad")
 (file-module! "prelude/ref.rad")
 (file-module! "prelude/lens.rad")
+(file-module! "prelude/key-management.rad")
 (file-module! "prelude/chain.rad")
 (file-module! "prelude/chain-remote.rad")
 (file-module! "prelude/state-machine.rad")

--- a/rad/prelude/chain.rad
+++ b/rad/prelude/chain.rad
@@ -12,6 +12,7 @@
 (import prelude/patterns :unqualified)
 (import prelude/strings :unqualified)
 (import prelude/seq :unqualified)
+(import prelude/key-management :as 'key-mgmt)
 
 (def base-send!
   "See documentation of `send!`"
@@ -264,6 +265,14 @@
   (fn [chain-id filename]
     (send! chain-id (io/read-file-values! filename))))
 
+(def get-keys!
+ (fn []
+   (match (key-mgmt/read-keys!)
+     :nothing (do (put-str! "Missing file: my-keys.rad
+Do `rad-create-keys` to create your own key pair and rerun your command.")
+                  (exit! 1))
+      'keys    keys)))
+
 (def sign-entity!
   "Assumes a key pair is stored at `my-keys.rad`. Using that key pair, will sign a
   dict by adding `:author` and `:signature` fields, so that it is valid
@@ -272,7 +281,7 @@
     (def nonce (uuid!))
     (def e_ (<> e {:chain-id chain-id
                    :nonce    nonce}))
-    (def ks (io/read-file-value! (find-module-file! "../my-keys.rad")))
+    (def ks (get-keys!))
     (def sig
       (gen-signature! (lookup :private-key ks)
                       (show e_)))

--- a/rad/prelude/key-management.rad
+++ b/rad/prelude/key-management.rad
@@ -16,21 +16,19 @@
     (set-ref key-pair-mode (@ :use-fake-key) #t)
     (set-ref key-pair-mode (@ :fake-key) (gen-key-pair! (default-ecc-curve)))))
 
-(def config-path
+(def base-path
   (fn []
     (def xgd-config-home (string/unlines (io/shell-with-stdout! "echo $XDG_CONFIG_HOME" "")))
-    (if (eq? xgd-config-home "")
-      "~/.config"
-      xgd-config-home)))
+    (def home (string/unlines (io/shell-with-stdout! "echo $XDG_CONFIG_HOME" "")))
+    (def config-path
+      (if (eq? xgd-config-home "")
+        (string-append home "/.config")
+        xgd-config-home))
+    (string-append config-path "/radicle")))
 
-(def base-path (string-append (config-path) "/radicle"))
-
-(def get-path!
+(def key-path
   (fn []
-    (def resolved-base-path
-      (string/unlines
-        (io/shell-with-stdout! (string-append "echo " base-path) "")))
-    (string-append resolved-base-path "/my-keys.rad")))
+    (string-append (base-path) "/my-keys.rad")))
 
 (def read-keys!
   "Reads the keys stored in `my-keys.rad` or returns `:nothing` if the file
@@ -39,13 +37,12 @@
     (if (lookup :use-fake-key (read-ref key-pair-mode))
       (lookup :fake-key (read-ref key-pair-mode))
       (do (catch 'any
-           (io/read-file-value! (find-module-file! (get-path!)))
+           (io/read-file-value! (find-module-file! (key-path)))
          (fn [x] :nothing))))))
 
 (def create-keys!
   "Creates a new key pair and stores it in `my-keys.rad`"
   (fn []
-    (io/shell! (string-append "mkdir -p " (config-path)) "")
-    (io/shell! (string-append "mkdir -p " base-path) "")
+    (io/shell! (string-append "mkdir -p " (base-path)) "")
     (def kp (gen-key-pair! (default-ecc-curve)))
-    (io/write-file! (get-path!) (show kp))))
+    (io/write-file! (key-path) (show kp))))

--- a/rad/prelude/key-management.rad
+++ b/rad/prelude/key-management.rad
@@ -1,5 +1,7 @@
 {:module 'prelude/key-management
- :doc "Functions for key management."
+ :doc "Providing functions for creating and reading key pairs for signing send
+ commands. Per default, key pairs are stored in `$HOME/.config/radicle/my-keys.rad`
+ this can be adjusted by setting `$XDG_CONFIG_HOME`."
  :exports '[read-keys! create-keys! use-fake-keys]}
 
 (import prelude/io :as 'io)

--- a/rad/prelude/key-management.rad
+++ b/rad/prelude/key-management.rad
@@ -1,0 +1,49 @@
+{:module 'prelude/key-management
+ :doc "Functions for key management."
+ :exports '[read-keys! create-keys! use-fake-keys]}
+
+(import prelude/io :as 'io)
+(import prelude/strings :as 'string)
+(import prelude/lens :unqualified)
+
+(def key-pair-mode (ref {:use-fake-key #f}))
+
+(def use-fake-keys
+  "Bypass reading the keys from `my-keys.rad`. This is intended for testing."
+  (fn []
+    (set-ref key-pair-mode (@ :use-fake-key) #t)
+    (set-ref key-pair-mode (@ :fake-key) (gen-key-pair! (default-ecc-curve)))))
+
+(def config-path
+  (fn []
+    (def xgd-config-home (string/unlines (io/shell-with-stdout! "echo $XDG_CONFIG_HOME" "")))
+    (if (eq? xgd-config-home "")
+      "~/.config"
+      xgd-config-home)))
+
+(def base-path (string-append (config-path) "/radicle"))
+
+(def get-path!
+  (fn []
+    (def resolved-base-path
+      (string/unlines
+        (io/shell-with-stdout! (string-append "echo " base-path) "")))
+    (string-append resolved-base-path "/my-keys.rad")))
+
+(def read-keys!
+  "Reads the keys stored in `my-keys.rad` or returns `:nothing` if the file
+  doesn't exist."
+  (fn []
+    (if (lookup :use-fake-key (read-ref key-pair-mode))
+      (lookup :fake-key (read-ref key-pair-mode))
+      (do (catch 'any
+           (io/read-file-value! (find-module-file! (get-path!)))
+         (fn [x] :nothing))))))
+
+(def create-keys!
+  "Creates a new key pair and stores it in `my-keys.rad`"
+  (fn []
+    (io/shell! (string-append "mkdir -p " (config-path)) "")
+    (io/shell! (string-append "mkdir -p " base-path) "")
+    (def kp (gen-key-pair! (default-ecc-curve)))
+    (io/write-file! (get-path!) (show kp))))

--- a/rad/prelude/key-management.rad
+++ b/rad/prelude/key-management.rad
@@ -2,7 +2,7 @@
  :doc "Providing functions for creating and reading key pairs for signing send
  commands. Per default, key pairs are stored in `$HOME/.config/radicle/my-keys.rad`
  this can be adjusted by setting `$XDG_CONFIG_HOME`."
- :exports '[read-keys! create-keys! use-fake-keys]}
+ :exports '[read-keys! create-keys! use-fake-keys!]}
 
 (import prelude/io :as 'io)
 (import prelude/strings :as 'string)
@@ -10,7 +10,7 @@
 
 (def key-pair-mode (ref {:use-fake-key #f}))
 
-(def use-fake-keys
+(def use-fake-keys!
   "Bypass reading the keys from `my-keys.rad`. This is intended for testing."
   (fn []
     (set-ref key-pair-mode (@ :use-fake-key) #t)
@@ -19,7 +19,7 @@
 (def base-path
   (fn []
     (def xgd-config-home (string/unlines (io/shell-with-stdout! "echo $XDG_CONFIG_HOME" "")))
-    (def home (string/unlines (io/shell-with-stdout! "echo $XDG_CONFIG_HOME" "")))
+    (def home (string/unlines (io/shell-with-stdout! "echo $HOME" "")))
     (def config-path
       (if (eq? xgd-config-home "")
         (string-append home "/.config")

--- a/reference-doc.yaml
+++ b/reference-doc.yaml
@@ -144,6 +144,7 @@ modules:
 - prelude/set
 - prelude/ref
 - prelude/lens
+- prelude/key-management
 - prelude/chain
 - prelude/state-machine
 - prelude/validation


### PR DESCRIPTION
Keys are now stored in `~/.config/radicle/my-keys.rad`, where the config directory can be adjusted via `$XDG_CONFIG_HOME`. 

Keys can be created via `rad-create-keys`, if `--force` is appended, an existing `my-keys.rad` is overwritten.