### PR TITLE
Only change state to accepted, if all git commands are through

### DIFF
--- a/bin/rad-diff
+++ b/bin/rad-diff
@@ -284,11 +284,10 @@
               (put-str! message)))
           (verify-diff-number n chain-ref)
           (if (eq? new-state :accepted)
-            (do
-              (match (push-diff! chain-ref n)
-                :ok (edit-state-with-feedback!
-                      (string-append "Diff " (show n) " has been " (pretty-state new-state) " and merged."))
-                _   (exit! 1)))
+            (match (push-diff! chain-ref n)
+              :ok (edit-state-with-feedback!
+                    (string-append "Diff " (show n) " has been " (pretty-state new-state) " and merged."))
+              _   (exit! 1))
             (edit-state-with-feedback!
               (string-append "Diff " (show n) " has been " (pretty-state new-state)))))
         (cmd-parse-failure "Diff numbers must be whole numbers!"))

--- a/bin/rad-diff
+++ b/bin/rad-diff
@@ -124,7 +124,6 @@
     (process! "git" ["checkout" "master"] "")
     (match (apply-patch! (lookup :patch diff))
       :ok (do
-            (put-str! "ok!")
             (process! "git" ["push"] ""))
       _   (do
             (put-str! "Resolve any conflicts and then run 'git push'")
@@ -277,14 +276,21 @@
   (fn [chain-name n new-state]
     (if (number? n)
       (if (integral? n)
-        (do (def chain-ref (chain/make-chain-ref! chain-name))
+        (do
+          (def chain-ref (chain/make-chain-ref! chain-name))
+          (def edit-state-with-feedback!
+            (fn [message]
+              (simple-edit-diff! chain-ref n {:state new-state})
+              (put-str! message)))
           (verify-diff-number n chain-ref)
-          (simple-edit-diff! chain-ref n {:state new-state})
           (if (eq? new-state :accepted)
             (do
-              (push-diff! chain-ref n)
-              (put-str! (string-append "Diff " (show n) " has been " (pretty-state new-state) " and merged.")))
-            (put-str! (string-append "Diff " (show n) " has been " (pretty-state new-state)))))
+              (match (push-diff! chain-ref n)
+                :ok (edit-state-with-feedback!
+                      (string-append "Diff " (show n) " has been " (pretty-state new-state) " and merged."))
+                _   (exit! 1)))
+            (edit-state-with-feedback!
+              (string-append "Diff " (show n) " has been " (pretty-state new-state)))))
         (cmd-parse-failure "Diff numbers must be whole numbers!"))
     (cmd-parse-failure "To change the state, please provide the diff number."))))
 


### PR DESCRIPTION
On accepting a diff, the state will only be changed once all git commands were done.

This still doesn't handle failed git commands properly (additional user feedback to resolve the problem & not all git commands are wrapped in error handling), but this should be addressed after some git refactoring.