### PR TITLE
Avoid confusion around git config project settings

### DIFF
--- a/bin/rad-project
+++ b/bin/rad-project
@@ -60,7 +60,7 @@
     (put-str! name)
     (process! "git" ["clone" origin name] "")
     (cd! name)
-    (set-git-config! "rad.project.url" project-url)))
+    (set-git-config! "radicle.project-id" project-url)))
 
 (def new-or-forked-project!
   "Create a new or forked project. If `maybe-upstream` is :nothing, creates a
@@ -90,7 +90,7 @@
     (add-rsm! project-rsm { :id repo-url :type :rad-repo })
     (add-rsm! project-rsm { :id issues-url :type :rad-issues })
     (add-rsm! project-rsm { :id diff-url :type :rad-diff })
-    (set-git-config! "rad.project.url" project-url)
+    (set-git-config! "radicle.project-id" project-url)
     (put-str! "=> project created!")))
 
 

--- a/rad/monadic/project.rad
+++ b/rad/monadic/project.rad
@@ -8,7 +8,7 @@
 
 (def get-project-url!
   (fn []
-    (def proj (get-git-config! "rad.project.url"))
+    (def proj (get-git-config! "radicle.project-id"))
     (if (eq? proj "")
         (do
           (put-str! "Not in a radicle project")


### PR DESCRIPTION
We use `radicle.project-id` instead of `rad.project.url` as the configuration key.

1. The project ID is not a URL
2. Better be explicit and not use abbreviations
3. Three level nesting is not necessary and leads to confusing config files