### PR TITLE
Handle failures in project checkout

### DIFF
--- a/bin/rad-project
+++ b/bin/rad-project
@@ -60,8 +60,8 @@
     (match (process! "test" ["-d" name] "")
       :ok (do
             (put-str! (string-append
-                        "The directory \"" name "\" already exists. "
-                        "It needs to be removed to checkout the project in this directory."))
+                        "The directory \"" name "\" already exists.\n"
+                        "Refusing to continue."))
             (exit! 1))
       _   (put-str! name))
     (match (process! "git" ["clone" origin name] "")
@@ -69,7 +69,10 @@
       _   (do
             (put-str! (string-append
                         "The repo is currently not available. "
-                        "Cloning \"" name "\" from \"" origin "\" failed."))
+                        "Cloning \"" name "\" from \"" origin "\" failed.\n"
+                        "This may be because you have no internet connection, "
+                        "or the IPNS link is stale, or because no online node "
+                        "with the data could be found."))
             (exit! 1)))
     (set-git-config! "radicle.project-id" project-url)))
 

--- a/bin/rad-project
+++ b/bin/rad-project
@@ -57,9 +57,20 @@
     (fetch! rsm)
     (def name (lookup :name (get-meta! rsm)))
     (def origin (lookup :id (first-rsm-of-type! rsm :rad-repo)))
-    (put-str! name)
-    (process! "git" ["clone" origin name] "")
-    (cd! name)
+    (match (process! "test" ["-d" name] "")
+      :ok (do
+            (put-str! (string-append
+                        "The directory \"" name "\" already exists. "
+                        "It needs to be removed to checkout the project in this directory."))
+            (exit! 1))
+      _   (put-str! name))
+    (match (process! "git" ["clone" origin name] "")
+      :ok (cd! name)
+      _   (do
+            (put-str! (string-append
+                        "The repo is currently not available. "
+                        "Cloning \"" name "\" from \"" origin "\" failed."))
+            (exit! 1)))
     (set-git-config! "radicle.project-id" project-url)))
 
 (def new-or-forked-project!


### PR DESCRIPTION
This handles if the directory already exists and if cloning the repository fails.

Refactoring processing of git commands will happen in a different PR, which will make this code cleaner.