### PR TITLE
Use public registry for 'ipfs-test-network' image

### DIFF
--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3'
 
 services:
   ipfs-test-network:
-    image: eu.gcr.io/opensourcecoin/ipfs-test-network
+    image: gcr.io/opensourcecoin/ipfs-test-network
     ports:
     - "19301:5001"
     command:


### PR DESCRIPTION
The e2e tests require the `ipfs-test-network` image. We get it from the `gcr.io` registry which is public, unlike `eu.gcr.io`.

See https://github.com/oscoin/ipfs-test-network-container