### PR TITLE
Daemon client URL configurable through environment

### DIFF
--- a/exe/Machines.hs
+++ b/exe/Machines.hs
@@ -6,7 +6,6 @@ module Machines
 import           Protolude hiding (option)
 
 import           Control.Exception.Safe
-import qualified Network.HTTP.Client as HttpClient
 import           Options.Applicative
 import qualified Radicle.Daemon.Client as Client
 
@@ -25,8 +24,8 @@ programParserInfo =
 
 runCommand :: Command -> IO ()
 runCommand CommandCreate = do
-    httpManager <- HttpClient.newManager HttpClient.defaultManagerSettings
-    runExceptT (Client.newMachine httpManager) >>= \case
+    client <- Client.newClient
+    runExceptT (Client.newMachine client) >>= \case
         Left err -> throw err
         Right (Client.MachineId machineId) -> putStrLn machineId
 

--- a/package.yaml
+++ b/package.yaml
@@ -196,7 +196,6 @@ executables:
     other-modules: []
     dependencies:
     - radicle
-    - http-client
     - optparse-applicative
     - safe-exceptions
     ghc-options: -main-is Machines

--- a/src/Radicle/Daemon/Client.hs
+++ b/src/Radicle/Daemon/Client.hs
@@ -4,6 +4,7 @@
 -- interpreter with @daemonClientPrimFns@.
 module Radicle.Daemon.Client
     ( createDaemonClientPrimFns
+    , newClient
     , newMachine
     , query
     , send
@@ -15,7 +16,8 @@ import           Protolude hiding (TypeError)
 import           Control.Monad.Except
 import           GHC.Exts (fromList)
 import qualified Network.HTTP.Client as HttpClient
-import           Servant.Client hiding (Client)
+import qualified Servant.Client as Servant
+import           System.Environment
 
 import           Radicle
 import           Radicle.Daemon.HttpApi
@@ -23,26 +25,41 @@ import qualified Radicle.Internal.PrimFns as PrimFns
 
 
 -- | Constraints for all client functions
-type Client m = (MonadIO m, MonadError ServantError m)
+type ClientM m = (MonadIO m, MonadError Servant.ServantError m)
+
+data Client = Client
+    { clientBaseUrl     :: Servant.BaseUrl
+    , clientHttpManager :: HttpClient.Manager
+    }
+
+-- | Create a new client for the daemon API. Reads the base URL from the
+-- @RAD_DAEMON_API_URL@ environment variable. If the variable is not set we use
+-- @http://localhost:8909@
+newClient :: IO Client
+newClient = do
+    baseUrlString <- fromMaybe "http://localhost:8909" <$> lookupEnv "RAD_DAEMON_API_URL"
+    clientBaseUrl <- Servant.parseBaseUrl baseUrlString
+    clientHttpManager <- HttpClient.newManager HttpClient.defaultManagerSettings
+    pure Client {..}
 
 -- | Send an input to a machine to be evaluated and applied. Returns the results
 -- of evaluting the inputs.
-send :: Client m => HttpClient.Manager -> MachineId -> Seq Value -> m [Value]
-send httpManager machineId inputs = do
-    SendResponse {..} <- runClient httpManager $ client machineSendEndpoint machineId (SendRequest $ toList inputs)
+send :: ClientM m => Client -> MachineId -> Seq Value -> m [Value]
+send client machineId inputs = do
+    SendResponse {..} <- runClient client $ Servant.client machineSendEndpoint machineId (SendRequest $ toList inputs)
     pure results
 
 -- | Send an expression to a machine to be evaluated and return the result of
 -- the evaluation. The state of the machine is not changed.
-query :: (Client m) => HttpClient.Manager -> MachineId -> Value -> m Value
-query httpManager machineId q = do
-    QueryResponse {..} <- runClient httpManager $ client machineQueryEndpoint machineId (QueryRequest q)
+query :: (ClientM m) => Client -> MachineId -> Value -> m Value
+query client machineId q = do
+    QueryResponse {..} <- runClient client $ Servant.client machineQueryEndpoint machineId (QueryRequest q)
     pure result
 
 -- | Create a new machine and return its ID.
-newMachine :: (Client m) => HttpClient.Manager -> m MachineId
-newMachine httpManager = do
-    NewResponse {..} <- runClient httpManager $ client newMachineEndpoint
+newMachine :: (ClientM m) => Client -> m MachineId
+newMachine client = do
+    NewResponse {..} <- runClient client $ Servant.client newMachineEndpoint
     pure machineId
 
 
@@ -50,11 +67,11 @@ newMachine httpManager = do
 -- @daemon/new-machine!@.
 createDaemonClientPrimFns ::(MonadIO m) => IO (PrimFns m)
 createDaemonClientPrimFns = do
-    httpManager <- HttpClient.newManager HttpClient.defaultManagerSettings
+    client <- newClient
     pure $ fromList
-        [ (unsafeToIdent sendName, Nothing, sendPrimFn httpManager)
-        , (unsafeToIdent queryName, Nothing, queryPrimFn httpManager)
-        , (unsafeToIdent newMachineName, Nothing, newMachinePrimFn httpManager)
+        [ (unsafeToIdent sendName, Nothing, sendPrimFn client)
+        , (unsafeToIdent queryName, Nothing, queryPrimFn client)
+        , (unsafeToIdent newMachineName, Nothing, newMachinePrimFn client)
         ]
   where
     sendName = "daemon/send!"
@@ -78,23 +95,20 @@ createDaemonClientPrimFns = do
 
 -- * Internal
 
-runClient :: forall a m. (Client m) => HttpClient.Manager -> ClientM a -> m a
-runClient httpManager clientAction = liftEither =<< liftIO runHttp
-  where
-    runHttp :: IO (Either ServantError a)
-    runHttp = do
-        baseUrl <- parseBaseUrl "http://localhost:8909"
-        let clientEnv = mkClientEnv httpManager baseUrl
-        runClientM clientAction clientEnv
+runClient :: forall a m. (ClientM m) => Client -> Servant.ClientM a -> m a
+runClient Client {..} clientAction = do
+    let clientEnv = Servant.mkClientEnv clientHttpManager clientBaseUrl
+    result <- liftIO $ Servant.runClientM clientAction clientEnv
+    liftEither result
 
 -- | Rethrow Servant error as Radicle language error
 --
 -- If the Servant error is 'FailureResponse' we wrap the content of the reponse
 -- body. Otherwise we use 'displayException'.
-wrapServantError :: Monad m => ExceptT ServantError m a -> Lang m a
+wrapServantError :: Monad m => ExceptT Servant.ServantError m a -> Lang m a
 wrapServantError action = do
     result <- lift $ runExceptT action
     case result of
-        Left (FailureResponse response) -> throwErrorHere $ OtherError $ toS $ responseBody response
+        Left (Servant.FailureResponse response) -> throwErrorHere $ OtherError $ toS $ Servant.responseBody response
         Left e -> throwErrorHere $ OtherError $ toS $ displayException e
         Right value -> pure value


### PR DESCRIPTION
The base URL for the daemon API is now configurable through the `RAD_DAEMON_API_URL` environment variable.