### PR TITLE
Isolate e2e tests

### DIFF
--- a/examples/radicle-counter
+++ b/examples/radicle-counter
@@ -60,19 +60,19 @@ fi
 case "$cmd" in
   init )
     radicle - <<-SCRIPT
-      (load! "rad/examples/counter.rad")
+      (load! (find-module-file! "examples/counter.rad"))
       (counter/init-machine! "${machine}")
 SCRIPT
     ;;
   get-value )
     radicle - <<-SCRIPT
-      (load! "rad/examples/counter.rad")
+      (load! (find-module-file! "examples/counter.rad"))
       (counter/get-value "${machine}")
 SCRIPT
     ;;
   increment )
     radicle - <<-SCRIPT
-      (load! "rad/examples/counter.rad")
+      (load! (find-module-file! "examples/counter.rad"))
       (counter/increment! "${machine}")
 SCRIPT
     ;;

--- a/package.yaml
+++ b/package.yaml
@@ -101,9 +101,14 @@ tests:
     - test/e2e
     dependencies:
     - process
+    - directory
+    - filepath
+    - safe-exceptions
     - tasty
     - tasty-discover
     - tasty-hunit
+    - temporary
+    - text
 
 executables:
   rad:

--- a/test/e2e/CounterAppTest.hs
+++ b/test/e2e/CounterAppTest.hs
@@ -5,67 +5,33 @@ module CounterAppTest
     ( test_counter_app
     ) where
 
-import           Prelude (String, unwords)
 import           Protolude
 
-import           Data.List (lookup)
-import           System.Environment
-import           System.Process
-import           Test.Tasty
-import           Test.Tasty.HUnit
+import           System.FilePath
+import           Test.E2ESupport
 
 test_counter_app :: TestTree
 test_counter_app = testCaseSteps "counter app" $ \step -> do
-        step "Create machine"
-        machineId <- runTestCommand "rad-machines" ["create"]
+    step "Create machine"
+    machineId <- runTestCommand "rad-machines" ["create"]
 
-        step "Initialize machine"
-        void $ runTestCommand "examples/radicle-counter" [machineId, "init"]
+    step "Initialize machine"
+    void $ runCounter [machineId, "init"]
 
-        initialValue <- runTestCommand "examples/radicle-counter" [machineId, "get-value"]
-        assertEqual "(get-value) on counter chain" "0" initialValue
+    initialValue <- runCounter [machineId, "get-value"]
+    assertEqual "(get-value) on counter chain" "0" initialValue
 
-        forM_ [(1::Int)..3] $ \i -> do
-            step $ "Increment to " <> show i
+    forM_ [(1::Int)..3] $ \i -> do
+        step $ "Increment to " <> show i
 
-            valueInc <- runTestCommand "examples/radicle-counter" [machineId, "increment"]
-            assertEqual "(increment) on counter chain" (show i) valueInc
+        valueInc <- runCounter [machineId, "increment"]
+        assertEqual "(increment) on counter chain" (show i) valueInc
 
-            valueGet <- runTestCommand "examples/radicle-counter" [machineId, "get-value"]
-            assertEqual "(get-value) on counter chain" (show i) valueGet
-
--- | Run a command with the given arguments and return stdout.
---
--- If the command exists with a non-zero exit code an exception is
--- thrown.
---
--- Set the @RAD_IPFS_API_URL@ to a value that makes it work for local
--- tests with @test/docker-compose.yaml@.
---
--- Any trailing newlines are stripped from the output.
-runTestCommand :: (HasCallStack) => FilePath -> [String] -> IO String
-runTestCommand bin args = do
-    env <- getEnvironment
-    let procEnv = setDefault "RAD_IPFS_API_URL" "http://localhost:19301" env
-    let procSpec = (proc bin args) { env = Just procEnv }
-    (exitCode, out, err) <- readCreateProcessWithExitCode procSpec ""
-    case exitCode of
-        ExitSuccess -> pure $ trimNewline out
-        ExitFailure _ ->
-            let commandLine = bin <> " " <> unwords args
-            in assertFailure $
-                "Command failed: " <> commandLine <> "\n"
-                <> "-- stdout ---------\n"
-                <> out
-                <> "-- stderr ---------\n"
-                <> err
-                <> "-------------------\n"
+        valueGet <- runCounter [machineId, "get-value"]
+        assertEqual "(get-value) on counter chain" (show i) valueGet
   where
-    setDefault :: Eq key => key -> value -> [(key, value)] -> [(key, value)]
-    setDefault defKey defValue items =
-        case lookup defKey items of
-            Nothing -> (defKey, defValue):items
-            Just _  -> items
-
-trimNewline :: String -> String
-trimNewline = reverse . dropWhile (=='\n') . reverse
+    runCounter :: [Text] -> TestM Text
+    runCounter args = do
+        p <- asks projectDir
+        let bin = p </> "examples" </> "radicle-counter"
+        runTestCommand bin (map toS args)

--- a/test/e2e/Test/E2ESupport.hs
+++ b/test/e2e/Test/E2ESupport.hs
@@ -1,0 +1,118 @@
+-- | This module provides functions for defining tests, making assertions, and
+-- interacting with the test environment. Import this module instead of
+-- "Test.Tasty" and its submodules.
+--
+-- We export a subset of the "Test.Tasty.HUnit" functions lifted to 'TestM'
+module Test.E2ESupport
+    ( TestM
+    , projectDir
+
+    , testCaseSteps
+    , runTestCommand
+
+    , TestTree
+    , assertEqual
+    ) where
+
+import           Prelude (String, unwords)
+import           Protolude hiding (bracket)
+
+import           Control.Exception.Safe
+import qualified Data.Text as T
+import           System.Directory
+import           System.Environment
+import           System.FilePath
+import           System.IO.Temp
+import           System.Process
+import           Test.Tasty
+import qualified Test.Tasty.HUnit as HUnit
+
+type TestM = ReaderT TestEnv IO
+
+data TestEnv = TestEnv
+    { homeDir    :: FilePath
+    , projectDir :: FilePath
+    }
+
+-- | Prepares 'TestEnv' by creating a temporary directory that serves as the
+-- home directory, then runs 'TestM' with the environment.
+--
+-- We also adjust the @PATH@ environment variable so that it includes the
+-- projects @bin@ folder.
+runTestM :: TestM a -> IO a
+runTestM testM = do
+    projectDir <- getCurrentDirectory
+    withSystemTempDirectory "radicle-test" $ \dir ->
+        let env = TestEnv
+                { homeDir = dir
+                , projectDir = projectDir
+                }
+        in withCurrentDirectory dir
+            $ withExtendedSearchPath (projectDir </> "bin")
+            $ runReaderT testM env
+  where
+    -- | Runs the given action with a modified search path that includes @path@.
+    withExtendedSearchPath :: FilePath -> IO a -> IO a
+    withExtendedSearchPath path action = bracket (prependSearchPath path) setSearchPath (const action)
+
+    -- | Prepend the path to the search path and return the original search path
+    prependSearchPath :: FilePath -> IO [FilePath]
+    prependSearchPath path = do
+        originalSearchPath <- getSearchPath
+        setSearchPath (path : originalSearchPath)
+        pure originalSearchPath
+
+    setSearchPath :: [FilePath] -> IO ()
+    setSearchPath paths = setEnv "PATH" $ intercalate [searchPathSeparator] paths
+
+
+-- * Lift test definitions and assertions to 'TestM'
+
+testCaseSteps :: TestName -> ((Text -> TestM ()) -> TestM ()) -> TestTree
+testCaseSteps name mkTest =
+    HUnit.testCaseSteps name $ \step ->
+        let step' = liftIO . step . toS
+        in runTestM (mkTest step')
+
+
+assertEqual :: (HasCallStack, MonadIO m, Eq a, Show a) => Text -> a -> a -> m ()
+assertEqual msg a a' = liftIO $ HUnit.assertEqual (toS msg) a a'
+
+-- * Run commands
+
+-- | Like 'runTestCommand'' but does not provide input to stdin.
+runTestCommand :: (HasCallStack) => FilePath -> [Text] -> TestM Text
+runTestCommand bin args = runTestCommand' bin args []
+
+-- | Run a command with the given arguments and stdin lines and return stdout.
+--
+-- The command is executed with @HOME@ set to 'homeDir' from the test
+-- environment.
+--
+-- Any trailing newlines are stripped from the output.
+--
+-- If the command exists with a non-zero exit code an exception is
+-- thrown.
+runTestCommand' :: (HasCallStack) => FilePath -> [Text] -> [Text] -> TestM Text
+runTestCommand' bin args inputLines = do
+    TestEnv {..} <- ask
+    searchPath <- liftIO $ getEnv "PATH"
+    let env = [("PATH", searchPath), ("HOME", homeDir), ("RADPATH", projectDir </> "rad")]
+    let argsString = map toS args
+    let procSpec = (proc bin argsString) { env = Just env }
+    let input = T.unpack $ T.intercalate "\n" inputLines
+    (exitCode, out, err) <- liftIO $ readCreateProcessWithExitCode procSpec input
+    case exitCode of
+        ExitSuccess -> pure $ toS $ trimNewline out
+        ExitFailure _ ->
+            let commandLine = bin <> " " <> unwords argsString
+            in liftIO $ HUnit.assertFailure $
+                "Command failed: " <> commandLine <> "\n"
+                <> "-- stdout ---------\n"
+                <> out
+                <> "-- stderr ---------\n"
+                <> err
+                <> "-------------------\n"
+
+trimNewline :: String -> String
+trimNewline = reverse . dropWhile (=='\n') . reverse


### PR DESCRIPTION
This commit improves the isolation of the end-to-end tests for the counter app by running the commands with a clean environment in a temporary directory.

This also necessitates some refactoring. We introduce the `Test.E2ESupport` module which provides the `TestM` monad. All generic code for tests is moved there.