### PR TITLE
Refactor git and handle git command failures

### DIFF
--- a/bin/rad-diff
+++ b/bin/rad-diff
@@ -85,31 +85,48 @@
 
 (def apply-patch!
   "Given a patch, apply it to the current branch"
-  (fn [patch]
+  (fn [patch msg]
     (def file (unlines (shell-with-stdout! "mktemp" "")))
     (put-str! file)
     (write-file! file patch)
-    (process! "git" ["am" file] "")))
+    (process-git-with-exit! ["am" file] msg)))
 
 (def checkout-diff!
   "Creates a new branch diff/<DIFF-ID> based on the DIFF, and switches to it."
   (fn [machine diff-no]
     (def diff (verify-diff-number diff-no machine))
-    (match (process! "git" ["checkout" "-b" (string-append "diff/" (show diff-no))] "")
-      :ok (apply-patch! (lookup :patch diff))
-      _   (put-str! (string-append "Command 'git checkout -b diff/" (show diff-no) "' failed")))))
+    (process-git-with-exit!
+      ["checkout" "-b" (string-append "diff/" (show diff-no))]
+      (string-append "Creating and switching to branch diff/" (show diff-no) "' failed."))
+    (apply-patch!
+      (lookup :patch diff)
+      (string-append
+        "Applying the patch failed.\n"
+        "Resolve any conflicts and run 'git am --continue', \n"
+        "or 'git am --abort' to abort."))))
 
 (def push-diff!
   "Merges the DIFF to master, and pushes the changes."
   (fn [machine diff-no]
     (def diff (verify-diff-number diff-no machine))
-    (process! "git" ["checkout" "master"] "")
-    (match (apply-patch! (lookup :patch diff))
-      :ok (do
-            (process! "git" ["push"] ""))
-      _   (do
-            (put-str! "Resolve any conflicts and then run 'git push'")
-            (exit! 1)))))
+    (process-git-with-exit!
+      ["checkout" "master"]
+      (string-append
+        "Checkout branch master failed.\n"
+        "Refusing to continue."))
+    (apply-patch!
+      (lookup :patch diff)
+      (string-append
+        "Applying the patch failed.\n"
+        "Resolve any conflicts and and then run 'git push', \n"
+        "or 'git am --abort' to abort."))
+    (process-git-with-exit!
+      ["push"]
+      (string-append
+        "Pushing the diff failed.\n"
+        "This may be because you have no internet connection, "
+        "you are not authorized to push to origin, "
+        "or the remote is currently not reachable."))))
 
 (def new-diff!
   "Creates a new diff on `machine` with a patch from the given `commit`."

--- a/bin/rad-diff
+++ b/bin/rad-diff
@@ -69,26 +69,19 @@
 
 (def get-title!
   (fn [commit]
-    (string/unlines (process-with-stdout! "git" ["show" "-s" "--format=%s" commit] ""))))
+    (get-git-commit-data! "%s" commit)))
 
 (def get-description!
   (fn [commit]
-    (string/unlines (process-with-stdout! "git" ["show" "-s" "--format=%b" commit] ""))))
+    (get-git-commit-data! "%b" commit)))
 
 (def get-author-name!
   (fn [commit]
-    (string/unlines (process-with-stdout! "git" ["show" "-s" "--format=%aN" commit] ""))))
-
-(def get-author-email!
-  (fn [commit]
-    (string/unlines (process-with-stdout! "git" ["show" "-s" "--format=%aE" commit] ""))))
+    (get-git-commit-data! "%aN" commit)))
 
 (def get-short-hash!
   (fn [commit]
     (string/unlines (process-with-stdout! "git" ["rev-parse" "--short" commit] ""))))
-
-(def get-git-username!
-  (string/unlines (process-with-stdout! "git" ["config" "user.name"] "")))
 
 (def apply-patch!
   "Given a patch, apply it to the current branch"

--- a/bin/rad-project
+++ b/bin/rad-project
@@ -62,16 +62,15 @@
                         "Refusing to continue."))
             (exit! 1))
       _   (put-str! name))
-    (match (process! "git" ["clone" origin name] "")
-      :ok (cd! name)
-      _   (do
-            (put-str! (string-append
-                        "The repo is currently not available. "
-                        "Cloning \"" name "\" from \"" origin "\" failed.\n"
-                        "This may be because you have no internet connection, "
-                        "or the IPNS link is stale, or because no online node "
-                        "with the data could be found."))
-            (exit! 1)))
+    (process-git-with-exit!
+      ["clone" origin name]
+      (string-append
+        "The repo is currently not available. "
+        "Cloning \"" name "\" from \"" origin "\" failed.\n"
+        "This may be because you have no internet connection, "
+        "or the IPNS link is stale, or because no online node "
+        "with the data could be found."))
+    (cd! name)
     (set-git-config! "radicle.project-id" project-url)))
 
 (def new-project!

--- a/rad/prelude/io-utils.rad
+++ b/rad/prelude/io-utils.rad
@@ -1,6 +1,7 @@
 {:module 'prelude/io-utils
  :doc "IO-related utilities"
- :exports '[fzf-select! edit-in-editor! get-git-config! set-git-config!]}
+ :exports '[fzf-select! edit-in-editor! get-git-config! set-git-config!
+            get-git-commit-data! get-git-username!]}
 
 (import prelude/io '[shell-with-stdout! write-file! process-with-stdout!] :unqualified)
 (import prelude/strings '[unlines] :unqualified)
@@ -45,7 +46,32 @@
   (fn [key]
     (unlines (process-with-stdout! "git" ["config" "--get" key] ""))))
 
+(def get-git-username!
+  "Get the user name stored in git config."
+  (fn []
+    (match (get-git-config! "user.name")
+      ""    (do
+                (put-str! (string-append
+                            "git config user.name is not set. "
+                            "Set the user name and rerun you command.")))
+      'name  name)))
+
+(def get-git-commit-data!
+  "Get data from a `commit` via `show` specified by `format`"
+  (fn [format commit]
+    (unlines
+      (process-with-stdout! "git" ["show" "-s" (string-append "--format=" format) commit] ""))))
+
 (def set-git-config!
   "Set the value associated with a key in git config."
   (fn [key value]
     (process-with-stdout! "git" ["config" key value] "")))
+
+(def process-git-with-exit!
+  "Processes a git command `args`. If it fails, the message `msg` is shown and the process exits, otherwise `:ok` is passed."
+  (fn [args msg]
+    (match (process! "git" args "")
+      :ok :ok
+      _   (do
+            (put-str! msg)
+            (exit! 1)))))

--- a/rad/prelude/io-utils.rad
+++ b/rad/prelude/io-utils.rad
@@ -53,14 +53,20 @@
       ""    (do
                 (put-str! (string-append
                             "git config user.name is not set. "
-                            "Set the user name and rerun you command.")))
+                            "Set the user name and rerun your command."))
+                (exit! 1))
       'name  name)))
 
 (def get-git-commit-data!
   "Get data from a `commit` via `show` specified by `format`"
   (fn [format commit]
-    (unlines
-      (process-with-stdout! "git" ["show" "-s" (string-append "--format=" format) commit] ""))))
+    (def git-args ["show" "-s" (string-append "--format=" format) commit])
+    (match (process-with-stdout-stderr-exitcode! "git" git-args "")
+      ['stdout _ :ok] (unlines stdout)
+      _               (do
+                        (put-str!
+                          (string-append "git show -s --format=" format " " commit " failed."))
+                        (exit! 1)))))
 
 (def set-git-config!
   "Set the value associated with a key in git config."


### PR DESCRIPTION
This handles most of the git commands. The error messages might not be comprehensive.

Some unhandled cmds remain in `new-or-forked-project!` in `rad-project`, but they are also part of open TODOs.