### PR TITLE
Extract machine config

### DIFF
--- a/exe/Daemon.hs
+++ b/exe/Daemon.hs
@@ -5,11 +5,10 @@
 -- See
 -- <https://github.com/oscoin/radicle/blob/master/rfcs/0003-radicle-daemon.rst
 -- the RFC>.
-module Daemon where
+module Daemon (main) where
 
 import           Protolude hiding (fromStrict, option, poll)
 
-import qualified Data.Aeson as A
 import           Data.ByteString.Lazy (fromStrict)
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
@@ -17,26 +16,24 @@ import qualified Data.Time.Clock.System as Time
 import           Network.Wai.Handler.Warp (run)
 import           Options.Applicative
 import           Servant
-import           System.Directory (doesFileExist)
 import           System.IO (BufferMode(..), hSetBuffering)
 
 import           Radicle.Daemon.Common hiding (logInfo)
 import qualified Radicle.Daemon.Common as Common
-import qualified Radicle.Internal.UUID as UUID
-
-import           Radicle hiding (Env)
 import qualified Radicle.Daemon.HttpApi as Api
 import           Radicle.Daemon.Ipfs
+import           Radicle.Daemon.MachineConfig
 import           Radicle.Daemon.Monad
+
+import           Radicle hiding (Env)
 import qualified Radicle.Internal.CLI as Local
 import qualified Radicle.Internal.ConcurrentMap as CMap
+import qualified Radicle.Internal.UUID as UUID
 
 -- * Types
 
 logDaemonError :: MonadIO m => Error -> m ()
 logDaemonError (displayError -> (m, xs)) = logErr m xs
-
-type Follows = Map MachineId ReaderOrWriter
 
 -- * Main
 
@@ -74,12 +71,12 @@ main :: IO Void
 main = do
     hSetBuffering stdout LineBuffering
     Opts{..} <- execParser allOpts
-    followFileLock <- newMVar ()
-    followFile <- Local.getRadicleFile (toS filePrefix <> "daemon-follows")
+    machineConfigFileLock <- newMVar ()
+    machineConfigFile <- Local.getRadicleFile (toS filePrefix <> "daemon-follows")
     machines <- CachedMachines <$> CMap.empty
     let env = Env{ logLevel = if debug then Debug else Normal, ..}
-    follows <- readFollowFileIO followFileLock followFile
-    initRes <- runDaemon env (init follows)
+    machineConfig <- readMachineConfigIO machineConfigFileLock machineConfigFile
+    initRes <- runDaemon env (init machineConfig)
     case initRes of
       Left err -> do
         logDaemonError err
@@ -133,7 +130,7 @@ server env = hoistServer Api.daemonApi nt daemonServer
 -- * Init
 
 -- | Initiate machines according to follow file.
-init :: Follows -> Daemon ()
+init :: MachineConfig -> Daemon ()
 init follows = traverse_ initMachine (Map.toList follows)
   where
     initMachine (id, Reader) = initReaderNoFail id
@@ -151,7 +148,7 @@ newMachine = do
     m <- liftIO $ emptyMachine id Writer sub
     insertNewMachine id (Cached m)
     actAsWriter m
-    writeFollowFile
+    writeMachineConfig
     pure (Api.NewResponse id)
 
 -- | Evaluate an expression against a cached machine. The resulting
@@ -233,32 +230,6 @@ logInfo l msg infos = do
     then Common.logInfo msg infos
     else pure ()
 
-withFollowFileLock :: FollowFileLock -> IO a -> IO a
-withFollowFileLock lock = withMVar lock . const
-
-readFollowFileIO :: FollowFileLock -> FilePath -> IO Follows
-readFollowFileIO lock ff = withFollowFileLock lock $ do
-  exists <- doesFileExist ff
-  t <- if exists
-    then readFile ff
-    else let noFollows = toS (A.encode (Map.empty :: Follows))
-         in writeFile ff noFollows $> noFollows
-  case A.decode (toS t) of
-    Nothing -> panic $ "Invalid daemon-follow file: could not decode " <> toS ff
-    Just fs -> pure fs
-
-writeFollowFile :: Daemon ()
-writeFollowFile = do
-    lock <- asks followFileLock
-    CachedMachines cMap <- asks machines
-    ff <- asks followFile
-    liftIO $ withFollowFileLock lock $ do
-      ms <- CMap.nonAtomicRead cMap
-      let fs = mode <$> ms
-      writeFile ff (toS (A.encode fs))
-  where
-    mode (UninitialisedReader _) = Reader
-    mode (Cached c)              = machineMode c
 
 lookupMachine :: MachineId -> Daemon (Maybe CachedMachine)
 lookupMachine id = do
@@ -416,7 +387,7 @@ initAsReader id = do
 newReader :: MachineId -> Daemon Machine
 newReader id = do
   m <- initAsReader id
-  writeFollowFile
+  writeMachineConfig
   pure m
 
 -- | Try to initiate a reader, but don't fail in case of errors; just log a

--- a/package.yaml
+++ b/package.yaml
@@ -138,11 +138,9 @@ executables:
     other-modules: []
     dependencies:
     - radicle
-    - aeson
     - mtl
     - containers
     - bytestring
-    - directory
     - optparse-applicative
     - servant-server
     - text

--- a/src/Radicle/Daemon/MachineConfig.hs
+++ b/src/Radicle/Daemon/MachineConfig.hs
@@ -1,0 +1,49 @@
+-- | This module provides disk persistence for 'MachineConfig'.
+-- 'MachineConfig' tells us which machine the daemon owns and which
+-- machines it follows.
+module Radicle.Daemon.MachineConfig
+    ( MachineConfig
+    , readMachineConfigIO
+    , writeMachineConfig
+    ) where
+
+import           Protolude
+
+import qualified Data.Aeson as A
+import qualified Data.Map.Strict as Map
+import           System.Directory (doesFileExist)
+
+import           Radicle.Daemon.Common
+import           Radicle.Daemon.Ipfs
+import           Radicle.Daemon.Monad
+import qualified Radicle.Internal.ConcurrentMap as CMap
+
+-- | Holds the machines the daemon owns and follows.
+type MachineConfig = Map MachineId ReaderOrWriter
+
+readMachineConfigIO :: FileLock -> FilePath -> IO MachineConfig
+readMachineConfigIO lock ff = withFileLock lock $ do
+  exists <- doesFileExist ff
+  t <- if exists
+    then readFile ff
+    else let noFollows = toS (A.encode (Map.empty :: MachineConfig))
+         in writeFile ff noFollows $> noFollows
+  case A.decode (toS t) of
+    Nothing -> panic $ "Invalid daemon-follow file: could not decode " <> toS ff
+    Just fs -> pure fs
+
+writeMachineConfig :: Daemon ()
+writeMachineConfig = do
+    lock <- asks machineConfigFileLock
+    CachedMachines cMap <- asks machines
+    ff <- asks machineConfigFile
+    liftIO $ withFileLock lock $ do
+      ms <- CMap.nonAtomicRead cMap
+      let fs = mode <$> ms
+      writeFile ff (toS (A.encode fs))
+  where
+    mode (UninitialisedReader _) = Reader
+    mode (Cached c)              = machineMode c
+
+withFileLock :: FileLock -> IO a -> IO a
+withFileLock lock = withMVar lock . const

--- a/src/Radicle/Daemon/Monad.hs
+++ b/src/Radicle/Daemon/Monad.hs
@@ -7,7 +7,7 @@ module Radicle.Daemon.Monad
     , liftExceptT
 
     , Env(..)
-    , FollowFileLock
+    , FileLock
     , LogLevel(..)
 
     , MachineError(..)
@@ -33,16 +33,16 @@ liftExceptT makeError action = Daemon $ mapExceptT (lift . fmap (first makeError
 
 -- * Environment
 
-type FollowFileLock = MVar ()
+type FileLock = MVar ()
 
 data LogLevel = Normal | Debug
   deriving (Eq, Ord)
 
 data Env = Env
-  { followFileLock :: FollowFileLock
-  , followFile     :: FilePath
-  , machines       :: CachedMachines
-  , logLevel       :: LogLevel
+  { machineConfigFileLock :: FileLock
+  , machineConfigFile     :: FilePath
+  , machines              :: CachedMachines
+  , logLevel              :: LogLevel
   }
 
 -- * Errors


### PR DESCRIPTION
We use the term “machine config” for what was called “follow file” and “follows”. We move everything related to that into its own module.

This is helpful preparation for improving the `filePrefix` option which
is required for testing.