### PR TITLE
Improved machine config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ The end-to-end test suite is run with `stack test :e2e`. It requires you to
 start up an IPFS test network and the Raicle daemon.
 
     docker-compose -f test/docker-compose.yaml up -d ipfs-test-network
-    RAD_IPFS_API_URL=http://localhost:19301 stack exec -- radicle-daemon --filePrefix test
+    RAD_IPFS_API_URL=http://localhost:19301 stack exec -- \
+      radicle-daemon --machine-config /tmp/radicle-machines.json
 
 If you use `docker-compose up` for the first time you will also need to
 initialize the IPFS test network with
@@ -63,8 +64,8 @@ initialize the IPFS test network with
     echo '{"radicle": true}' | \
       docker-compose -f test/docker-compose.yaml exec -T ipfs-test-network ipfs dag put
 
-You can reset the test daemon’s state by removing the file
-`./local/share/radicle/testdaemon-follows`.
+You can reset the test daemon’s machine configuration by removing the file
+`/tmp/radicle-machines.json`.
 
 ### Troubleshooting
 

--- a/package.yaml
+++ b/package.yaml
@@ -206,6 +206,7 @@ executables:
 
 default-extensions:
 - AutoDeriveTypeable
+- ApplicativeDo
 - ConstraintKinds
 - DataKinds
 - DefaultSignatures


### PR DESCRIPTION
We rename the `--filePrefix` option to `--machine-config`. We also change the options behavior so that it does take a full path and not just a prefix.

After this users must manually move `~/.local/share/radicle/daemon-follows` to `~/.local/share/radicle/machines.json`