### PR TITLE
Use common base image for CI steps

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,34 @@
+# Base image for Google Cloud Build build steps.
+#
+# Includes the following tools
+#
+# - ghc v8.6.3
+# - stack v1.9.1
+# - gcloud
+# - gsutil
+# - docker client v18.09.2
+# - docker-compose v1.23.2
+
+FROM haskell:8.6.3
+
+ENTRYPOINT []
+
+# Install `gcloud` and `gsutil`
+ADD https://packages.cloud.google.com/apt/doc/apt-key.gpg google-apt-key.gpg
+RUN \
+  echo "deb http://packages.cloud.google.com/apt cloud-sdk-stretch main" \
+    > /etc/apt/sources.list.d/google-cloud-sdk.list && \
+  apt-key add google-apt-key.gpg && \
+  apt-get update -yqq && \
+  apt-get -yq install google-cloud-sdk && \
+  rm -rf /var/lib/apt/lists/*
+
+# Install `docker`
+ADD https://download.docker.com/linux/static/stable/x86_64/docker-18.09.2.tgz docker.tgz
+RUN \
+  tar --extract --file docker.tgz --strip-components 1 --directory /usr/local/bin/ && \
+  rm docker.tgz
+
+# Install `docker-compose`
+ADD https://github.com/docker/compose/releases/download/1.23.2/docker-compose-Linux-x86_64 /usr/local/bin/docker-compose
+RUN chmod +x /usr/local/bin/docker-compose

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,23 @@
 timeout: 3600s # Cache misses are slow to rebuild
+substitutions:
+  # Bump the version if you make changes to `ci/Dockerfile
+  _BUILD_IMAGE: eu.gcr.io/opensourcecoin/radicle-ci:v1
 steps:
+  - id: "Build CI base image"
+    name: gcr.io/cloud-builders/docker
+    entrypoint: 'bash'
+    args:
+    - '-c'
+    - |
+      set -euxo pipefail
+
+      if ! docker pull $_BUILD_IMAGE; then
+        docker build ci --tag $_BUILD_IMAGE
+        docker push $_BUILD_IMAGE
+      fi
+
   - id: "Load cache"
-    name: gcr.io/cloud-builders/gsutil
+    name: $_BUILD_IMAGE
     entrypoint: 'bash'
     args:
     - '-c'
@@ -12,7 +28,7 @@ steps:
       load-cache
 
   - id: "Build deps"
-    name: 'haskell:8.6.3'
+    name: $_BUILD_IMAGE
     env: ['STACK_ROOT=/workspace/.stack']
     entrypoint: 'bash'
     args:
@@ -34,7 +50,7 @@ steps:
 
   - id: "Save cache"
     waitFor: ["Build deps"]
-    name: gcr.io/cloud-builders/gsutil
+    name: $_BUILD_IMAGE
     entrypoint: 'bash'
     env:
     - BRANCH_NAME=$BRANCH_NAME
@@ -47,17 +63,17 @@ steps:
       save-cache
 
   - id: "Format"
-    name: 'haskell:8.6.3'
+    name: $_BUILD_IMAGE
     env: ['STACK_ROOT=/workspace/.stack']
     args: ['./scripts/check-fmt.sh']
 
   - id: "Lint"
-    name: 'haskell:8.6.3'
+    name: $_BUILD_IMAGE
     env: ['STACK_ROOT=/workspace/.stack']
     args: ['stack', 'exec', '--', 'hlint', '.']
 
   - id: "Build"
-    name: 'haskell:8.6.3'
+    name: $_BUILD_IMAGE
     env: ['STACK_ROOT=/workspace/.stack']
     entrypoint: bash
     args:
@@ -73,7 +89,7 @@ steps:
         --no-run-tests
 
   - id: "Test"
-    name: 'haskell:8.6.3'
+    name: $_BUILD_IMAGE
     env: ['STACK_ROOT=/workspace/.stack']
     entrypoint: bash
     args:
@@ -87,14 +103,14 @@ steps:
 
   - id: "Lint (weeder)"
     waitFor: ["Build"]
-    name: 'haskell:8.6.3'
+    name: $_BUILD_IMAGE
     env: ["STACK_ROOT=/workspace/.stack"]
     args: ["stack", "exec", "--", "weeder", "--match"]
 
   - id: "Build reference document"
     waitFor:
     - "Build"
-    name: 'haskell:8.6.3'
+    name: $_BUILD_IMAGE
     env: ['STACK_ROOT=/workspace/.stack']
     entrypoint: bash
     args:
@@ -112,7 +128,7 @@ steps:
   - id: "Check tutorial"
     waitFor:
     - "Build"
-    name: 'haskell:8.6.3'
+    name: $_BUILD_IMAGE
     env: ['STACK_ROOT=/workspace/.stack']
     entrypoint: bash
     args:
@@ -123,8 +139,8 @@ steps:
       RADPATH="$(pwd)/rad" stack exec radicle-doc docs/source/guide/Basics.lrad
 
   - id: "Start IPFS daemon"
-    name: 'docker/compose:1.23.2'
-    entrypoint: sh
+    name: $_BUILD_IMAGE
+    entrypoint: bash
     args:
     - "-c"
     - |
@@ -144,7 +160,7 @@ steps:
   - id: "Integration tests"
     waitFor:
     - "Start IPFS daemon"
-    name: 'haskell:8.6.3'
+    name: $_BUILD_IMAGE
     env: ['STACK_ROOT=/workspace/.stack']
     entrypoint: 'bash'
     args:


### PR DESCRIPTION
Use common base image for all Google Cloud Build steps. This image is
build in the first step from `ci/Dockerfile` and contains all necessary
tools.