### PR TITLE
Install 'git-remote-ipfs' for tests

### DIFF
--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -23,3 +23,5 @@
       - depends:
         # Required as compiler plugin
         - tasty-discover
+        # Library is not required, but executable
+        - git-remote-ipfs

--- a/package.yaml
+++ b/package.yaml
@@ -103,6 +103,8 @@ tests:
     - process
     - directory
     - filepath
+    # Requires the 'git-remote-ipfs' executable
+    - git-remote-ipfs
     - safe-exceptions
     - tasty
     - tasty-discover

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -11,14 +11,17 @@ resolver: lts-13.2
 packages:
 - base58-bytestring-0.1.0@sha256:a1da72ee89d5450bac1c792d9fcbe95ed7154ab7246f2172b57bd4fd9b5eab79
 - cborg-0.2.1.0
+- git-0.3.0
 - github-0.20
 - sandi-0.4.3@sha256:2ada9c759424f243095ab28b55687cdec4e9d16bac3589f9d200280207c50216
 - serialise-0.2.1.0
 - git: https://github.com/oscoin/ipfs.git
   commit: 19b25fa4d0003b5c2027c8cc1b8a3c36ac2f9f60
   subdirs:
+  - ipfs-api
   - ipld-cid
   - binary-varint
+  - git-remote-ipfs
   - multibase
   - multihash-cryptonite
 


### PR DESCRIPTION
We add `git-remote-ipfs` as a dependency for the end-to-end tests. We don’t use the library but the `git-remote-ipfs` binary will be available for the tests.