### PR TITLE
ci: Also cache test dependencies

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -29,6 +29,7 @@ steps:
 
       stack build \
         --no-terminal \
+        --test \
         --dependencies-only
 
   - id: "Save cache"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 dependency_hash=$( (cat package.yaml; cat snapshot.yaml) | sha256sum | cut -d ' ' -f 1)
 
-remote="gs://radicle-build-cache/v3"
+remote="gs://radicle-build-cache/v4"
 
 local_cache_archive="stack-root.tar.gz"
 remote_cache_master="$remote/stack-root-master.tar.gz"


### PR DESCRIPTION
We make sure that dependencies of the test targets are also cached.