### PR TITLE
ci: Stream unpacking cache

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -13,14 +13,10 @@ remote_cache_hashed="$remote/stack-root-${dependency_hash}.tar.gz"
 function load-cache() {
   if gsutil -q ls "$remote_cache_hashed"; then
     echo "Using hashed stack cache"
-    gsutil -m cp "$remote_cache_hashed" "$local_cache_archive"
-    tar xzf "$local_cache_archive"
-    rm "$local_cache_archive"
+    gsutil cat "$remote_cache_hashed" | tar -xz
   elif gsutil -q ls "$remote_cache_master"; then
     echo "Using master stack cache"
-    gsutil -m cp "$remote_cache_master" "$local_cache_archive"
-    tar xzf "$local_cache_archive"
-    rm "$local_cache_archive"
+    gsutil cat "$remote_cache_master" | tar -xz
   fi
 }
 


### PR DESCRIPTION
Instead of downloading the cache tar archive to disk and extracting it from there we pipe the download into tar and extract while downloading.

Improves the time to load the cache from 43 seconds to 37 seconds.