### PR TITLE
macOS build + packaging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,124 @@
+version: 2
+jobs:
+  build:
+    macos:
+      xcode: "10.0.0"
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - stack-root-{{ arch }}-ghc8.6.3-{{ checksum "snapshot.yaml" }}-{{ checksum "package.yaml" }}
+            - stack-root-{{ arch }}-ghc8.6.3-{{ checksum "snapshot.yaml" }}
+            - stack-root-{{ arch }}-ghc8.6.3-
+
+      - restore_cache:
+          keys:
+            - toolchain-{{ arch }}
+
+      - restore_cache:
+          keys:
+            - homebrew-{{ epoch }}
+            - homebrew-
+            - homebrew
+
+      - run:
+          name: Setup Toolchain
+          command: |
+            if ! [ -x $HOME/.ghcup/bin/ghcup ]; then
+              mkdir -p $HOME/.ghcup/bin
+              cd $HOME/.ghcup/bin
+              curl -LO https://github.com/haskell/ghcup/releases/download/0.0.7/ghcup
+              chmod +x $HOME/.ghcup/bin/ghcup
+            fi
+
+            export PATH="$HOME/.cabal/bin:$HOME/.ghcup/bin:$PATH"
+
+            command -v ghc || {
+              ghcup install "8.6.3"
+              ghcup set "8.6.3"
+            }
+
+            command -v cabal || ghcup install-cabal "2.4.1.0"
+
+            command -v stack || {
+              curl -sSL https://get.haskellstack.org/ | sh
+              stack config set system-ghc --global true
+              stack config set install-ghc --global false
+            }
+
+            echo 'export PATH="$HOME/.cabal/bin:$HOME/.ghcup/bin:$PATH"' >> $BASH_ENV
+
+      - save_cache:
+          key: toolchain-{{ arch }}
+          paths:
+            - "~/.ghcup"
+            - /usr/local/bin/stack
+
+      - run:
+          name: Homebrew Dependencies
+          command: |
+            brew install coreutils
+            if [[ "$CIRCLE_BRANCH" == "master" ]]; then
+              brew tap caskroom/cask
+              brew cask install google-cloud-sdk
+            fi
+
+      - save_cache:
+          key: homebrew-{{ epoch }}
+          paths:
+            - /usr/local/Homebrew
+
+      - run:
+          name: Build Dependencies
+          command: stack build --no-terminal --dependencies-only
+
+      - save_cache:
+          key: stack-root-{{ arch }}-ghc8.6.3-{{ checksum "snapshot.yaml" }}-{{ checksum "package.yaml" }}
+          paths:
+            - "~/.stack"
+
+      - run:
+          name: Build Executables
+          command: |
+            cabal v1-update
+            cabal v1-configure \
+              --prefix=/usr/local \
+              --docdir=/usr/local/share/doc/radicle \
+              --libsubdir=radicle \
+              --datasubdir=radicle \
+              --libexecsubdir=radicle \
+              --package-db="$(stack path --snapshot-pkg-db)" \
+              --package-db="$(stack path --local-pkg-db)" \
+              --package-db="$(stack path --global-pkg-db)"
+            cabal v1-build
+
+      - run:
+          name: Package
+          command: |
+            if [[ "$CIRCLE_BRANCH" == "master" ]]; then
+              cabal v1-copy \
+                exe:rad \
+                exe:radicle \
+                exe:radicle-daemon \
+                exe:rad-machines \
+                --destdir=dist/package-root
+
+              mkdir -p dist/pkg
+              tarball=radicle_${CIRCLE_SHA1}_x86_64-darwin.tar.gz
+              tar -C dist/package-root -cvzf dist/pkg/$tarball usr
+              sha512sum dist/pkg/$tarball|cut -d ' ' -f1 > dist/pkg/${tarball}.sha512
+            fi
+
+      - run:
+          name: Upload to Google Cloud Storage
+          command: |
+            if [[ "$CIRCLE_BRANCH" == "master" ]]; then
+              # Key ID: db4e4a0b0ee696ea6f263c20de593c2fba4d0998
+              echo "$GCLOUD_SERVICE_KEY" | \
+                gcloud auth activate-service-account \
+                  circleci-image-uploader@opensourcecoin.iam.gserviceaccount.com \
+                  --key-file=-
+
+              gsutil -m cp dist/pkg/* gs://static.radicle.xyz/releases/
+            fi


### PR DESCRIPTION
Adds a macOS build on CircleCI including a tarball deploy to Goog Clown Storage (`master` only)

Follow-up considerations:

* Will need to insert coins to keep CCI macOS executor going
* Wrapper scripts (as to-be-introduced in `f/packaging`) are not included in the tarball
* The procedure to cut a proper release is TBD. We may want to employ a different means fornaming/versioning the tarball