### PR TITLE
Use smaller 'haskell' image for docker builds

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -49,7 +49,7 @@ docker:
   # The default "host" does not work if the host version of stack is
   # not statically linked, which is the case on Arch.
   stack-exe: download
-  repo: "fpco/stack-build:lts-13.2"
+  repo: "haskell:8.6.3"
 
 # Extra package databases containing global packages
 # extra-package-dbs: []


### PR DESCRIPTION
We use the smaller `haskell:8.6.3` image for building the project with `stack --docker`. We used the large image initially because it contained the postgres libraries that we need to build the server.