### PR TITLE
Install scripts on `stack install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ You will need [`stack`](https://docs.haskellstack.org/en/stable/install_and_upgr
 Then run:
 
 ```
-stack install
+stack build
+stack install :rad
 ```
 
 Note: `stack` will need about 4GB of memory to compile successfully.

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wall -Werror #-}
+module Main (main) where
+
+import           Prelude
+
+import           Data.Foldable (forM_)
+import           Data.List (isPrefixOf)
+import           System.Directory
+import           System.FilePath ((</>))
+
+import           Distribution.PackageDescription (PackageDescription)
+import           Distribution.Simple
+import           Distribution.Simple.InstallDirs (InstallDirs(..))
+import           Distribution.Simple.LocalBuildInfo
+                 (LocalBuildInfo(..), absoluteInstallDirs)
+import           Distribution.Simple.Setup
+import           Distribution.Simple.Utils (installExecutableFile)
+
+main :: IO ()
+main = defaultMainWithHooks simpleUserHooks
+    {postCopy = copySubCommands}
+
+
+-- | Installs all files matching @bin/rad-*@ into the configured
+-- @bindir@, say @/usr/local/bin@.
+copySubCommands :: Args -> CopyFlags -> PackageDescription -> LocalBuildInfo -> IO ()
+copySubCommands _args copyFlags packageDescription localBuildInfo = do
+    let copyDest' = fromFlag $ copyDest copyFlags
+    let targetBindir = bindir $ absoluteInstallDirs packageDescription localBuildInfo copyDest'
+    let verbosity = fromFlag $ configVerbosity $ configFlags localBuildInfo
+    subCommands <- getSubCommands
+    forM_ subCommands $ \name ->
+        installExecutableFile verbosity (searchDir </> name) (targetBindir </> name)
+  where
+    radPrefix :: String
+    radPrefix = "rad-"
+
+    searchDir :: FilePath
+    searchDir = "bin"
+
+    getSubCommands :: IO [String]
+    getSubCommands = do
+        files <- listDirectory searchDir
+        pure $ filter (isPrefixOf radPrefix) files

--- a/bin/rad-project
+++ b/bin/rad-project
@@ -38,12 +38,12 @@
     (def key
       (unlines
         (process-with-stdout!
-          "rad-ipfs"
-          ["key" "gen" "--type=ed25519" keyname]
+          "rad"
+          ["ipfs" "key" "gen" "--type=ed25519" keyname]
           "")))
     (process-with-stdout!
-      "rad-ipfs"
-      ["name" "publish" "--key" key orig-cid]
+      "rad"
+      ["ipfs" "name" "publish" "--key" key orig-cid]
       "")
     (def remote (string-append "ipfs://ipns/" key))
     remote))

--- a/package.yaml
+++ b/package.yaml
@@ -8,6 +8,15 @@ extra-source-files:
 - README.md
 - ChangeLog.md
 
+build-type: Custom
+
+custom-setup:
+  dependencies:
+    - base >= 4 && <5
+    - Cabal
+    - filepath
+    - directory
+
 dependencies:
 - base >=4 && <5
 - protolude


### PR DESCRIPTION
All the `rad-*` scripts in `bin` are also installed when running `stack install`. This allows the `rad` command to pick them up.