### PR TITLE
Write machines.json upon writing to IPFS

### DIFF
--- a/exe/Daemon.hs
+++ b/exe/Daemon.hs
@@ -474,6 +474,7 @@ actAsWriter m = do
 writeInputs :: MachineId -> [Value] -> Maybe Text -> Daemon [Value]
 writeInputs id is nonce = do
     (rs, idx) <- modifyMachine id (addInputs is write pub)
+    writeMachineConfig
     logInfo Debug "Wrote inputs to IPFS" [ ("machine-id", getMachineId id)
                                          , ("new-input-index", show idx) ]
     pure rs


### PR DESCRIPTION
Because for writers it contains the latest entry index.