### PR TITLE
Improve error message when IPFS daemon not reachable

### DIFF
--- a/src/Radicle/Daemon/Monad.hs
+++ b/src/Radicle/Daemon/Monad.hs
@@ -78,4 +78,4 @@ displayError = \case
       IpfsExceptionErrRespNoMsg -> ("There was an unknown error using IPFS", [])
       IpfsExceptionTimeout -> ("Timeout communicating with IPFS daemon", [])
       IpfsExceptionInvalidResponse url parseError -> ("Cannot parse IPFS daemon response", [("url", url), ("parse-error", parseError)])
-      IpfsExceptionNoDaemon -> ("The IPFS daemon is not reachable, run 'rad ipfs daemon'", [])
+      IpfsExceptionNoDaemon -> ("Cannot connect to the IPFS daemon", [])


### PR DESCRIPTION
The error message that is logged by the daemon when it fails to connect to the IPFS daemon is made clearer. We remove the reference to the non-existing command.