### PR TITLE
Extract error messages for command parsing

### DIFF
--- a/rad/prelude.rad
+++ b/rad/prelude.rad
@@ -15,7 +15,6 @@
 (file-module! "prelude/ref.rad")
 (file-module! "prelude/lens.rad")
 (file-module! "prelude/key-management.rad")
-(file-module! "prelude/error-messages.rad")
 (file-module! "prelude/machine.rad")
 (file-module! "prelude/machine-remote.rad")
 (file-module! "prelude/state-machine.rad")

--- a/rad/prelude.rad
+++ b/rad/prelude.rad
@@ -15,6 +15,7 @@
 (file-module! "prelude/ref.rad")
 (file-module! "prelude/lens.rad")
 (file-module! "prelude/key-management.rad")
+(file-module! "prelude/error-messages.rad")
 (file-module! "prelude/machine.rad")
 (file-module! "prelude/machine-remote.rad")
 (file-module! "prelude/state-machine.rad")

--- a/rad/prelude/cmd-parsing.rad
+++ b/rad/prelude/cmd-parsing.rad
@@ -10,6 +10,8 @@
 (import prelude/lens :unqualified)
 (import prelude/seq :unqualified)
 (import prelude/strings :unqualified)
+
+(file-module! "prelude/error-messages.rad")
 (import prelude/error-messages :as 'error)
 
 (def parse-failure-mode (ref {:stub #f}))

--- a/rad/prelude/cmd-parsing.rad
+++ b/rad/prelude/cmd-parsing.rad
@@ -10,6 +10,7 @@
 (import prelude/lens :unqualified)
 (import prelude/seq :unqualified)
 (import prelude/strings :unqualified)
+(import prelude/error-messages :as 'error)
 
 (def parse-failure-mode (ref {:stub #f}))
 
@@ -27,14 +28,6 @@
   (fn [cmd opts]
     (catch 'invalid-input (cmd opts) (fn [x] x))))
 
-(def missing-arg-error
-  (fn [arg cmd]
-    (string-append "Missing argument \"" (show arg) "\" for command \"" cmd "\"")))
-
-(def too-many-args-error
-  (fn [cmd]
-    (string-append "Too many arguments for command \"" cmd "\"")))
-
 (def /cmd-opts
   "Matches the command `cmd` and a combination of options `opt`. The options
   need to be one of `:options` of the dicts in `cmd-opts`. In that list each
@@ -51,29 +44,27 @@
         (def parse-arg
           (fn [opt args]
             (def opt-key (lookup :key opt))
-            (def valid-args-help
-              (string-append "Valid arguments: " (intercalate ", "(lookup :possible-values opt))))
+            (def valid-args
+              (lookup :possible-values opt))
             (match args
               (/cons 'val 'rest)
-                  (if (elem? val (lookup :possible-values opt))
+                  (if (elem? val valid-args)
                     (modify-map opt-key (fn [x] (cons val x)) (parse-cli rest))
                     (do
                       (if (starts-with? val "-")
                         (parse-failure
-                          (string-append "Missing argument for option \"" (show opt-key) "\". " valid-args-help) help)
+                          (error/missing-arg-for-opt (show opt-key) valid-args) help)
                         (parse-failure
-                          (string-append
-                            "Invalid argument \"" val "\" for option \"" (show opt-key) "\". "
-                            valid-args-help)
+                          (error/invalid-arg-for-opt val (show opt-key) valid-args)
                           help))))
               []  (parse-failure
-                    (string-append "Missing argument for option \"" (show opt-key) "\". " valid-args-help) help)
+                    (error/missing-arg-for-opt (show opt-key) valid-args) help)
               )))
         (def parse-opt
           (fn [opt rest]
             (def option
               (match (filter (fn [x] (elem? opt (lookup :options x))) cmd-opts)
-                []    (parse-failure (string-append "Invalid option \"" opt "\" for command list.") help)
+                []    (parse-failure (error/invalid-opt-for-cmd opt "list") help)
                 'filt (first filt)))
             (if (eq? (lookup :type option) :flag)
               (insert (lookup :key option) #t (parse-cli rest))
@@ -118,9 +109,9 @@
     (fn [value]
       (match value
         [cmd 'a-1 'a-2] (match-pat [arg-1 arg-2] [a-1 a-2])
-        [cmd _] (parse-failure (missing-arg-error arg-2 cmd) help)
-        [cmd] (parse-failure (missing-arg-error arg-1 cmd) help)
-        (/cons cmd _) (parse-failure (too-many-args-error cmd) help)
+        [cmd _] (parse-failure (error/missing-arg (show arg-2) cmd) help)
+        [cmd] (parse-failure (error/missing-arg (show arg-1) cmd) help)
+        (/cons cmd _) (parse-failure (error/too-many-args cmd) help)
         _ :nothing))))
 
 (:test "/cmd-2"
@@ -142,8 +133,8 @@
     (fn [value]
       (match value
         [cmd 'cmd-args] (match-pat cmd-args-pat cmd-args)
-        [cmd] (parse-failure (missing-arg-error cmd-args-pat cmd) help)
-        (/cons cmd _) (parse-failure (too-many-args-error cmd) help)
+        [cmd] (parse-failure (error/missing-arg (show cmd-args-pat) cmd) help)
+        (/cons cmd _) (parse-failure (error/too-many-args cmd) help)
         _ :nothing))))
 
 (:test "/cmd-1"
@@ -163,7 +154,7 @@
     (fn [value]
      (match value
        [cmd] [:just {}]
-       (/cons cmd _) (parse-failure (too-many-args-error cmd) help)
+       (/cons cmd _) (parse-failure (error/too-many-args cmd) help)
        _ :nothing))))
 
 (:test "/cmd-0"

--- a/rad/prelude/error-messages.rad
+++ b/rad/prelude/error-messages.rad
@@ -1,0 +1,55 @@
+{:module 'prelude/error-messages
+ :doc "Functions for user facing error messages."
+ :exports
+ '[missing-arg too-many-args missing-arg-for-opt invalid-arg-for-opt
+   invalid-opt-for-cmd]}
+
+(import prelude/strings :unqualified)
+
+;; parsing
+
+(def missing-arg
+  (fn [arg cmd]
+    (string-append "Missing argument \"" arg "\" for command \"" cmd "\"")))
+
+(:test "missing-arg"
+  [(missing-arg "foo" "bar") ==> "Missing argument \"foo\" for command \"bar\""])
+
+(def too-many-args
+  (fn [cmd]
+    (string-append "Too many arguments for command \"" cmd "\"")))
+
+(:test "too-many-args"
+  [(too-many-args "foobar") ==> "Too many arguments for command \"foobar\""])
+
+(def valid-args-help
+  (fn [args]
+    (string-append "Valid arguments: " (intercalate ", " args))))
+
+(:test "valid-args-help"
+  [(valid-args-help ["foo" "bar"]) ==> "Valid arguments: foo, bar"])
+
+(def missing-arg-for-opt
+  (fn [opt valid-args]
+    (string-append
+      "Missing argument for option \"" opt "\". "
+      (valid-args-help valid-args))))
+
+(:test "missing-arg-for-opt"
+  [(missing-arg-for-opt "-s" ["foo" "bar"]) ==> "Missing argument for option \"-s\". Valid arguments: foo, bar"])
+
+(def invalid-arg-for-opt
+  (fn [arg opt valid-args]
+    (string-append
+      "Invalid argument \"" arg "\" for option \"" opt "\". "
+      (valid-args-help valid-args))))
+
+(:test "invalid-arg-for-opt"
+  [(invalid-arg-for-opt "foobar" "-s" ["foo" "bar"]) ==> "Invalid argument \"foobar\" for option \"-s\". Valid arguments: foo, bar"])
+
+(def invalid-opt-for-cmd
+  (fn [opt cmd]
+    (string-append "Invalid option \"" opt "\" for command " cmd ".")))
+
+(:test "invalid-opt-for-cmd"
+  [(invalid-opt-for-cmd "foo" "list") ==> "Invalid option \"foo\" for command list."])

--- a/rad/prelude/error-messages.rad
+++ b/rad/prelude/error-messages.rad
@@ -1,5 +1,8 @@
 {:module 'prelude/error-messages
- :doc "Functions for user facing error messages."
+ :doc "Functions for user facing error messages.
+ Functions should either have a descriptive name or additional comment so that
+ the text can be edited without knowledge of where they are used.
+ To verify changes, tests can be run with `stack exec -- radicle test/all.rad`"
  :exports
  '[missing-arg too-many-args missing-arg-for-opt invalid-arg-for-opt
    invalid-opt-for-cmd]}


### PR DESCRIPTION
This is the first step of extracting all user facing error messages. Once we agree on the format, this should be extended to the apps and other parts that produce user facing errors.

My idea here was that all user facing errors (produced by radicle code) are collected here and separated into section (not by file where they are used, but by topic). Each function for an error message has a simple test. Like this, changes can be tested locally with `stack exec -- radicle test/all.rad`, both the tests from `error-messages.rad` and where they are actually used.