### PR TITLE
Set STACK_ROOT when building daemon image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -115,6 +115,7 @@ steps:
     name: $_BUILD_IMAGE
     entrypoint: bash
     env:
+    - STACK_ROOT=/workspace/.stack
     - COMMIT_SHA=$COMMIT_SHA
     - BRANCH_NAME=$BRANCH_NAME
     args:


### PR DESCRIPTION
We set the `STACK_ROOT` environment variable for the “Build rad-daemon-radicle” build step. The build steps uses `stack` and without setting `STACK_ROOT` it will install GHC.