### PR TITLE
Add 'bin' folder to extra-source-files

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -7,6 +7,7 @@ git: oscoin/radicle
 extra-source-files:
 - README.md
 - ChangeLog.md
+- bin/*
 
 build-type: Custom
 


### PR DESCRIPTION
Add all files in the `bin` folder to the package’s `extra-source-files`. Now, if we change any of the files in `bin` then `stack build` will copy them again to the install directory and the `rad` command will pick up the changed files.