### PR TITLE
daemon: Wait for IPFS daemon

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -155,6 +155,7 @@ executables:
     - mtl
     - containers
     - optparse-applicative
+    - safe-exceptions
     - servant-server
     - text
     - warp

--- a/src/Radicle/Daemon/Monad.hs
+++ b/src/Radicle/Daemon/Monad.hs
@@ -61,10 +61,12 @@ data MachineError
 data Error
   = MachineError MachineId MachineError
   | CouldNotCreateMachine IpfsException
+  | IpfsDaemonNotReachable
 
 displayError :: Error -> (Text, [(Text,Text)])
 displayError = \case
   CouldNotCreateMachine (ipfsErr -> (msg, infos)) -> ("Could not create IPFS machine", ("message", msg) : infos)
+  IpfsDaemonNotReachable -> ("Could not connect to Radicle IPFS daemon", [])
   MachineError id e -> let mid = ("machine-id", getMachineId id) in
     case e of
       InvalidInput err -> ("Invalid radicle input", [mid, ("radicle-error", renderCompactPretty err)])

--- a/src/Radicle/Ipfs.hs
+++ b/src/Radicle/Ipfs.hs
@@ -8,6 +8,9 @@ module Radicle.Ipfs
     , addressToText
     , addressFromText
 
+    , VersionResponse(..)
+    , version
+
     , KeyGenResponse(..)
     , keyGen
 
@@ -144,6 +147,16 @@ addressFromText t =
 --------------------------------------------------------------------------
 -- * IPFS node API
 --------------------------------------------------------------------------
+
+newtype VersionResponse = VersionResponse Text
+
+instance FromJSON VersionResponse where
+    parseJSON = Aeson.withObject "VersionResponse" $ \o -> do
+        v <- o .: "Version"
+        pure $ VersionResponse v
+
+version :: IO VersionResponse
+version = ipfsHttpGet "version" []
 
 data PubsubMessage = PubsubMessage
     { messageTopicIDs :: [Text]


### PR DESCRIPTION
With systemd the Radicle daemon is started very quickly after the IPFS daemon has started. Therefore the IPFS daemon might not be ready yet when the Radicle daemon tries to load the machines. This results in errors.

To prevent this the Radicle daemon waits until the IPFS daemon is ready by repeatedly trying to connect to its `version` endpoint.