### PR TITLE
Document installation on Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ rad daemon-ipfs
 [ipfs]: https://docs.ipfs.io/introduction/install/
 [git-remote-ipfs]: https://github.com/oscoin/ipfs/tree/master/git-remote-ipfs#install
 
+### Debian/Ubuntu
+
+We provide `.deb` packages for Debian-based systems.
+
+    wget https://storage.googleapis.com/static.radicle.xyz/releases/radicle_2019.03.01_amd64.deb
+    apt install ./radicle_2019.03.01_amd64.deb
+
+To use Radicle you need to start the Radicle daemon
+
+    systemctl --user start radicle-daemon
+    systemctl --user status radicle-daemon
+
 ## Usage
 
 ```
@@ -48,7 +60,7 @@ rad> (fac 6)
 
 We are currently using `radicle` itself to manage issues, and have therefore
 disabled issues on Github. You can create and see issues with the
-`bin/rad-issue` script. You can also reach us on the `radicle` IRC channel on
+`bin/rad-issues` script. You can also reach us on the `radicle` IRC channel on
 `#freenode`.
 
 ## Development

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -219,6 +219,14 @@ steps:
     - |
       set -euxo pipefail
 
-      version="$(date +%Y.%m.%d)-$SHORT_SHA"
+      date=$(date +%Y.%m.%d)
+      version="$date-$SHORT_SHA"
       VERSION=$version TARGET=debian ./packaging/build-package.sh
+
+      if [ "$BRANCH_NAME" == "master" ]; then
+        cp  \
+          "packaging/out/radicle_${version}_amd64.deb" \
+          "packaging/out/radicle_${date}_amd64.deb"
+      fi
+
       ./packaging/upload.sh


### PR DESCRIPTION
Document how to install Radicle on Debian.

Also create dedicated master branch package When building `master` we create and upload a `radile_YYY.MM.DD_amd64.deb` package so that it is easy to get the latest radicle build without knowning the hash.