### PR TITLE
Always exit with error if key is missing

### DIFF
--- a/bin/rad-project
+++ b/bin/rad-project
@@ -151,6 +151,7 @@
 (def new-project!
   "Create a new project."
   (fn []
+    (get-keys!) ;; exit with error when key file does not exist
     (def meta (prompt-for-metadata!))
     (def project (create-project! meta))
     (if (not (detect-git!))

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -1165,6 +1165,12 @@ commands. Per default, key pairs are stored in
 Reads the keys stored in ``my-keys.rad`` or returns ``:nothing`` if the
 file doesn't exist.
 
+``(get-keys!)``
+~~~~~~~~~~~~~~~
+
+Like ``read-keys`` but prints an error message and exits the process if
+no key file was found.
+
 ``(create-keys!)``
 ~~~~~~~~~~~~~~~~~~
 

--- a/rad/monadic/diff.rad
+++ b/rad/monadic/diff.rad
@@ -4,7 +4,7 @@
 (import prelude/machine '[send-code!] :unqualified)
 (import prelude/time '[install-fake-clock] :unqualified)
 (import prelude/io :as 'io)
-(import prelude/key-management '[set-fake-keys! use-fake-keys! read-keys!] :unqualified)
+(import prelude/key-management '[set-fake-keys! use-fake-keys! get-keys!] :unqualified)
 
 (def radicle-diff-machine-id
   "The name of this machine."
@@ -13,7 +13,7 @@
 (def create-diff-machine!
   "Create a remote diff machine. Returns the machine id"
   (fn []
-    (def owner-keys (lookup :public-key (read-keys!)))
+    (def owner-keys (lookup :public-key (get-keys!)))
     (def id (machine/new-machine!))
     (machine/send-prelude! id)
     (send-code! id (find-module-file! "monadic/diff-remote.rad"))

--- a/rad/monadic/issue.rad
+++ b/rad/monadic/issue.rad
@@ -8,7 +8,7 @@
 (import prelude/machine '[send-code! send-signed-command!] :unqualified)
 (import prelude/time '[install-fake-clock] :unqualified)
 (import prelude/io :as 'io)
-(import prelude/key-management '[use-fake-keys! read-keys!] :unqualified)
+(import prelude/key-management '[use-fake-keys! get-keys!] :unqualified)
 
 (def radicle-issue-machine-id
   "The name of this machine."
@@ -17,7 +17,7 @@
 (def create-issue-machine!
   "Create a remote issue machine with the given url."
   (fn []
-    (def owner-keys (lookup :public-key (read-keys!)))
+    (def owner-keys (lookup :public-key (get-keys!)))
     (def id (machine/new-machine!))
     (machine/send-prelude! id)
     (send-code! id (find-module-file! "monadic/issue-remote.rad"))

--- a/rad/monadic/project.rad
+++ b/rad/monadic/project.rad
@@ -9,7 +9,7 @@
 (import prelude/machine '[send-code! send-signed-command! new-machine!] :unqualified)
 (import prelude/time '[install-fake-clock] :unqualified)
 (import prelude/io :as 'io)
-(import prelude/key-management '[use-fake-keys! read-keys!] :unqualified)
+(import prelude/key-management '[use-fake-keys! get-keys!] :unqualified)
 
 (def get-project-url!
   (fn []
@@ -37,7 +37,7 @@
 (def create-project!
   "Create a remote project RSM with the given url."
   (fn [meta]
-    (def owner-keys (lookup :public-key (read-keys!)))
+    (def owner-keys (lookup :public-key (get-keys!)))
     (def id (new-machine!))
     (machine/send-prelude! id)
     (send-code! id (find-module-file! "monadic/project-remote.rad"))

--- a/rad/prelude/key-management.rad
+++ b/rad/prelude/key-management.rad
@@ -2,11 +2,14 @@
  :doc "Providing functions for creating and reading key pairs for signing send
  commands. Per default, key pairs are stored in `$HOME/.config/radicle/my-keys.rad`
  this can be adjusted by setting `$XDG_CONFIG_HOME`."
- :exports '[read-keys! create-keys! set-fake-keys! use-fake-keys!]}
+ :exports '[read-keys! get-keys! create-keys! set-fake-keys! use-fake-keys!]}
 
 (import prelude/io :as 'io)
 (import prelude/strings :as 'string)
 (import prelude/lens :unqualified)
+
+(file-module! "prelude/error-messages.rad")
+(import prelude/error-messages :as 'error)
 
 (def key-pair-mode (ref {:use-fake-key #f}))
 
@@ -42,9 +45,18 @@
   (fn []
     (if (lookup :use-fake-key (read-ref key-pair-mode))
       (lookup :fake-key (read-ref key-pair-mode))
-      (do (catch 'any
-           (io/read-file-value! (find-module-file! (key-path)))
-         (fn [x] :nothing))))))
+      (catch 'any
+        (io/read-file-value! (key-path))
+        (fn [x] :nothing)))))
+
+(def get-keys!
+  "Like `read-keys` but prints an error message and exits the process if no key
+  file was found."
+  (fn []
+    (match (read-keys!)
+      :nothing (do (put-str! (error/missing-key-file))
+                   (exit! 1))
+      'keys    keys)))
 
 (def create-keys!
   "Creates a new key pair and stores it in `my-keys.rad`. Returns the

--- a/rad/prelude/machine.rad
+++ b/rad/prelude/machine.rad
@@ -12,10 +12,7 @@
 (import prelude/patterns :unqualified)
 (import prelude/strings :unqualified)
 (import prelude/seq :unqualified)
-(import prelude/key-management :as 'key-mgmt)
-
-(file-module! "prelude/error-messages.rad")
-(import prelude/error-messages :as 'error)
+(import prelude/key-management '[get-keys!] :unqualified)
 
 (def primitive-stub-ref/send! (ref daemon/send!))
 (def send!
@@ -173,13 +170,6 @@
   "Send code from a file to a remote machine."
   (fn [machine-id filename]
     (send! machine-id (io/read-file-values! filename))))
-
-(def get-keys!
- (fn []
-   (match (key-mgmt/read-keys!)
-     :nothing (do (put-str! (error/missing-key-file))
-                  (exit! 1))
-      'keys    keys)))
 
 (def sign-entity!
   "Assumes a key pair is stored at `my-keys.rad`. Using that key pair, will sign a


### PR DESCRIPTION
We make sure that all commands show an error message and exit if the user keys are missing. Before we would throw a cryptic exception because `read-keys!` returned `:nothing`.