### PR TITLE
Make pattern matching work in prelude modules

### DIFF
--- a/rad/prelude.rad
+++ b/rad/prelude.rad
@@ -3,6 +3,10 @@
 
 (file-module! "prelude/basic.rad")
 (file-module! "prelude/patterns.rad")
+;; Adds the special function `match-pat` to the global scope. This is
+;; required for the extended `match` to work in the modules loaded
+;; after.
+(import prelude/patterns :unqualified)
 (file-module! "prelude/bool.rad")
 (file-module! "prelude/seq.rad")
 (file-module! "prelude/strings.rad")
@@ -28,7 +32,6 @@
 (file-module! "prelude/cmd-parsing.rad")
 
 (import prelude/basic :unqualified)
-(import prelude/patterns :unqualified)
 (import prelude/bool :unqualified)
 (import prelude/seq :unqualified)
 (import prelude/strings :as 'string)


### PR DESCRIPTION
This fixes a bug where one of the prelude modules uses extended pattern matching (as defined in `match-pat`) without importing `prelude/patterns`.

For example one of the prelude modules may contain the code

    (def foo
      (match bar
        :foo #t
        _    #f))

If `match-pat` from `prelude/patterns` is not in the global environment when this module is evaluated then the `match` special form will call the matcher `:foo` as a function which will throw an error.