### PR TITLE
rad-project: Error when 'rad ipfs' fails

### DIFF
--- a/bin/rad-project
+++ b/bin/rad-project
@@ -39,15 +39,22 @@
   (fn [orig-cid]
     (def keyname (uuid!))
     (def key
-      (unlines
-        (process-with-stdout!
-          "rad"
-          ["ipfs" "key" "gen" "--type=ed25519" keyname]
-          "")))
-    (process-with-stdout!
-      "rad"
-      ["ipfs" "name" "publish" "--key" key orig-cid]
-      "")
+      (match
+        (process-with-stdout-stderr-exitcode!
+          "rad" ["ipfs" "key" "gen" "--type=ed25519" keyname] "")
+        ['stdout _ :ok] (unlines stdout)
+        ['stdout 'stderr _]
+          (do
+            (put-str! (error/rad-ipfs-key-gen-failure (unlines stderr)))
+            (exit! 1))))
+    (match
+      (process-with-stdout-stderr-exitcode!
+        "rad" ["ipfs" "name" "publish" "--key" key orig-cid] "")
+      ['stdout _ :ok] :ok
+      ['stdout 'stderr _]
+        (do
+          (put-str! (error/rad-ipfs-name-publish-failure (unlines stderr)))
+          (exit! 1)))
     (def remote (string-append "ipfs://ipns/" key))
     remote))
 

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -908,7 +908,8 @@ user input is a security hazard! Example: ``(shell! "ls -Glah" "")``.
 
 Executes ``command`` using ``execvp`` with ``to-write`` as input. Stdout
 and stderr are inherited. See ``man exec`` for more information on
-``execvp``. Example: ``(process! "ls" ["-Glah"] "")``.
+``execvp``. Returns ``:ok`` if the process exited normally and
+``[:error n]`` otherwise. Example: ``(process! "ls" ["-Glah"] "")``.
 
 ``(read-line!)``
 ~~~~~~~~~~~~~~~~
@@ -990,7 +991,8 @@ This requires the ``prelude/test/primitive-stub`` script to be loaded.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Like ``process-with-stdout!``, but returns a vec
-``[stdout stderr exitcode]``.
+``[stdout stderr exitcode]``. ``exitcode`` is either ``:ok`` or
+``[:error n]`` where ``n`` is a number.
 
 ``(prompt! prompt)``
 ~~~~~~~~~~~~~~~~~~~~

--- a/rad/prelude/error-messages.rad
+++ b/rad/prelude/error-messages.rad
@@ -9,7 +9,9 @@
    upstream-push-failure item-not-found whole-item-number missing-item-number
    state-change-failure no-number-returned unknown-command unknown-commit
    checkout-new-branch-failure checkout-master-failure applying-patch-failure
-   applying-accepted-patch-failure push-diff-failure missing-key-file]}
+   applying-accepted-patch-failure push-diff-failure missing-key-file
+   rad-ipfs-name-publish-failure rad-ipfs-key-gen-failure
+   ]}
 
 (import prelude/strings :unqualified)
 
@@ -273,3 +275,26 @@ This may be because you have no internet connection, you are not authorized to p
 (:test "missing-key-file"
   [(missing-key-file) ==> "Missing file: my-keys.rad
 Do `rad key create` to create your own key pair and rerun your command."])
+
+(def rad-ipfs-key-gen-failure
+  "Printed when the `rad ipfs key gen` command in `init-git-ipfs-repo`
+  in `rad-project` fails. Takes stderr of the command as an argument."
+  (fn [stderr]
+    (string-append
+      "error: Failed to create key for Git IPFS repository:\n"
+      stderr)))
+
+(:test "rad-ipfs-key-gen-failure"
+  [(rad-ipfs-key-gen-failure "stderr") ==>  "error: Failed to create key for Git IPFS repository:\nstderr"])
+
+(def rad-ipfs-name-publish-failure
+  "Printed when the `rad ipfs name publish` command in
+  `init-git-ipfs-repo` in `rad-project` fails. Takes stderr of the
+  command as an argument."
+  (fn [stderr]
+    (string-append
+      "error: Failed to publish key for Git IPFS repository:\n"
+      stderr)))
+
+(:test "rad-ipfs-name-publish-failure"
+  [(rad-ipfs-name-publish-failure "stderr") ==>  "error: Failed to publish key for Git IPFS repository:\nstderr"])

--- a/rad/prelude/io.rad
+++ b/rad/prelude/io.rad
@@ -116,8 +116,9 @@ Example: `(shell-no-stdin! \"ls -Glah\")`. "
 
 (def process!
   "Executes `command` using `execvp` with `to-write` as input. Stdout and stderr are inherited.
-See `man exec` for more information on `execvp`.
-Example: `(process! \"ls\" [\"-Glah\"] \"\")`. "
+See `man exec` for more information on `execvp`. Returns `:ok` if the
+process exited normally and `[:error n]` otherwise. Example: `(process!
+\"ls\" [\"-Glah\"] \"\")`. "
   (fn [command args to-write]
     (def cp
       { :cmdspec [:raw command args]
@@ -164,7 +165,8 @@ Example: `(process! \"ls\" [\"-Glah\"] \"\")`. "
 )
 
 (def process-with-stdout-stderr-exitcode!
-  "Like `process-with-stdout!`, but returns a vec `[stdout stderr exitcode]`."
+  "Like `process-with-stdout!`, but returns a vec `[stdout stderr exitcode]`.
+  `exitcode` is either `:ok` or `[:error n]` where `n` is a number."
   (fn [command args to-write]
     (def cp
       { :cmdspec [:raw command args]


### PR DESCRIPTION
We show an error and exit when the `rad ipfs` commands used by `rad project` fail to work.