### PR TITLE
'rad-project' uses modules

### DIFF
--- a/bin/rad-project
+++ b/bin/rad-project
@@ -1,16 +1,24 @@
 #!/usr/bin/env radicle
 
 (load! (find-module-file! "prelude.rad"))
-(load! (find-module-file! "monadic/issue.rad"))
-(load! (find-module-file! "monadic/diff.rad"))
-(load! (find-module-file! "monadic/project.rad"))
-(load! (find-module-file! "prelude/io-utils.rad"))
-
+(file-module! "prelude/io-utils.rad")
 (file-module! "prelude/error-messages.rad")
-(import prelude/error-messages :as 'error)
+(file-module! "monadic/issue.rad")
+(load! (find-module-file! "monadic/diff.rad"))
+(file-module! "monadic/project.rad")
 
+(import prelude/strings '[unlines] :unqualified)
+(import prelude/error-messages :as 'error)
 (import prelude/validation :as 'validation)
 (import prelude/cmd-parsing :unqualified)
+(import prelude/io-utils
+  '[set-git-config get-git-config process-git-with-exit!]
+  :unqualified)
+
+(import monadic/issue '[create-issue-machine!] :unqualified)
+(import monadic/project
+  '[get-project-url! get-meta create-project! add-rsm! first-rsm-of-type!]
+  :unqualified)
 
 (def help
   "rad-project - Radicle project CLI

--- a/rad/monadic/project.rad
+++ b/rad/monadic/project.rad
@@ -1,4 +1,9 @@
 ;; Helpers for setting up and interacting with project RSMs
+{:module  'monadic/project
+ :doc     "Interact with projects and project machines"
+ :exports '[get-project-url! get-meta! create-project! add-rsm!
+            first-rsm-of-type!
+           ]}
 
 (import prelude/lens :unqualified)
 (import prelude/machine '[send-code! send-signed-command! new-machine!] :unqualified)

--- a/rad/prelude/io-utils.rad
+++ b/rad/prelude/io-utils.rad
@@ -1,7 +1,8 @@
 {:module 'prelude/io-utils
  :doc "IO-related utilities"
  :exports '[fzf-select! edit-in-editor! get-git-config! set-git-config!
-            get-git-commit-data! get-git-username!]}
+            get-git-commit-data! get-git-username! process-git-with-exit!
+            ]}
 
 (import prelude/io '[shell-with-stdout! write-file! process-with-stdout!] :unqualified)
 (import prelude/strings '[unlines] :unqualified)

--- a/test/e2e/ProjectAppTest.hs
+++ b/test/e2e/ProjectAppTest.hs
@@ -1,0 +1,17 @@
+module ProjectAppTest
+    ( test_project_show_id
+    ) where
+
+import           Protolude
+
+import           Test.E2ESupport
+
+test_project_show_id :: TestTree
+test_project_show_id = testCase "project show-id" $ do
+    _ <- runTestCommand "rad-key" ["create"]
+    _ <- runTestCommand "git" ["config", "--global", "user.name", "Alice"]
+    _ <- runTestCommand "git" ["config", "--global", "user.email", "alice@example.com"]
+    _ <- runTestCommand' "rad-project" ["init"] ["project-name", "project desc", "1"]
+    projectId <- runTestCommand "git" ["config", "--get" ,"radicle.project-id"]
+    showIdOut <- runTestCommand' "rad-project" ["show-id"] []
+    assertContains showIdOut projectId

--- a/test/e2e/Test/E2ESupport.hs
+++ b/test/e2e/Test/E2ESupport.hs
@@ -8,6 +8,8 @@ module Test.E2ESupport
     , projectDir
 
     , testCaseSteps
+    , testCase
+
     , runTestCommand
     , runTestCommand'
 
@@ -75,6 +77,10 @@ testCaseSteps name mkTest =
     HUnit.testCaseSteps name $ \step ->
         let step' = liftIO . step . toS
         in runTestM (mkTest step')
+
+testCase :: TestName -> TestM () -> TestTree
+testCase name test =
+    HUnit.testCase name $ runTestM test
 
 
 assertEqual :: (HasCallStack, MonadIO m, Eq a, Show a) => Text -> a -> a -> m ()


### PR DESCRIPTION
`bin/rad-project` now uses modules instead of `load!`. We also add some tests for `project show-id` to ensure that this works.