### PR TITLE
Use MonadUnliftIO for Daemon

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -68,6 +68,7 @@ library:
   - template-haskell
   - text
   - time
+  - unliftio-core
   - unordered-containers
   - uuid
   - wreq


### PR DESCRIPTION
`Daemon` gets a `MonadUnliftIO` instance and we generalize the functions in `Radicle.Internal.ConcurrentMap` to use the `MonadUnliftIO` constraint instead of `IO`.

The immediate benefit is that `Daemon.modifyMachine` is simplified: The control logic is extracted and we focus on the domain logic.

The change will also make similar patterns easier to implement in the future.