### PR TITLE
Better concurrency properties for ConcurrentMap

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -80,6 +80,7 @@ tests:
     - test/spec
     dependencies:
     - radicle
+    - async
     - containers
     - cryptonite
     - directory
@@ -91,6 +92,7 @@ tests:
     - quickcheck-instances
     - scientific
     - serialise
+    - stm
     - string-qq
     - tasty
     - tasty-hunit

--- a/test/spec/Radicle/Internal/ConcurrentMapTest.hs
+++ b/test/spec/Radicle/Internal/ConcurrentMapTest.hs
@@ -1,0 +1,89 @@
+module Radicle.Internal.ConcurrentMapTest
+    ( test_
+    ) where
+
+import           Protolude
+
+import           Control.Concurrent.Async
+import           Control.Concurrent.STM
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+import qualified Radicle.Internal.ConcurrentMap as CMap
+
+
+test_ :: TestTree
+test_ = testGroup "Radicle.Internal.ConcurrentMap"
+
+    [ testCase "modifyValue is atomic for same key" $ do
+        cmap :: CMap.CMap () Int <- CMap.empty
+        let concurrency = 100
+        results <- replicateConcurrently concurrency $ CMap.modifyValue () cmap $ \case
+            Nothing -> do
+                -- We delay the thread so that an invocation of
+                -- 'modifyValue' does not finish before the next one is
+                -- started
+                threadDelay (5 * 1000)
+                pure (Just 1, 1)
+            Just x -> do
+                threadDelay (1 * 1000)
+                pure (Just (x + 1), x + 1)
+
+        sort results @?= [1..concurrency]
+
+        finalValue <- CMap.lookup () cmap
+        finalValue @?= Just concurrency
+
+
+    -- Test that 'modifyValue' operations for different keys can be run
+    -- concurrently. We check that by having all the invocations of the
+    -- function passed to 'modifyValue' block until they have
+    -- sychronized.
+    , testCase "modifyValue no contention" $ do
+        cmap :: CMap.CMap Int () <- CMap.empty
+
+        insertsVar <- newTVarIO (0 :: Int)
+        modificationsVar <- newTVarIO (0 :: Int)
+
+        let concurrency = 100
+
+        -- 'syncThreads tvar' blocks until 'concurrency' threads have
+        -- entered the action 'syncThreads'
+        let syncThreads tvar = do
+                atomically $ modifyTVar' tvar (+ 1)
+                -- This transaction blocks until the value in 'tvar' is
+                -- @concurrency@
+                atomically $ do
+                    x <- readTVar tvar
+                    check $ x == concurrency
+
+        forConcurrently [1..concurrency] $ \key ->
+            -- We run this twice to hit the 'Nothing' case and the
+            -- 'Just' case
+            replicateM_ 2 $
+                CMap.modifyValue key cmap $ \case
+                    Nothing -> do
+                        syncThreads insertsVar
+                        pure (Just (), ())
+                    Just _ -> do
+                        syncThreads modificationsVar
+                        pure (Just (), ())
+
+        inserts <- readTVarIO insertsVar
+        inserts @?= concurrency
+
+        modifications <- readTVarIO modificationsVar
+        modifications @?= concurrency
+
+
+    , testCase "modifyExistingValue is atomic for same key" $ do
+        cmap :: CMap.CMap () Int <- CMap.empty
+        CMap.insert () 0 cmap
+        results <- replicateConcurrently 100 $ CMap.modifyExistingValue () cmap $ \x -> do
+            threadDelay 1000
+            pure (x + 1, x + 1)
+        sort results @?= [ Just x | x <- [1..100] ]
+
+        finalValue <- CMap.lookup () cmap
+        finalValue @?= Just 100
+    ]


### PR DESCRIPTION
We improve contention of `modifyValue`. Before, two actions `modifyValue k1 f1` and `modifyValue k2 f2` would always contend. Now they can run
concurrently if `k1` and `k2` are different. Only if `k1 == k2` does one action wait for the other.

The change also allows `modifyExistingValue` to use `modifyValue` without loosing any of its concurrency properties.

While `modifyValue` is not currently used this change allows us to use it instead of `insert` in the future. This will prevent race conditions where multiple threads insert a value in the map.